### PR TITLE
add healthcheck for Haven on all networks

### DIFF
--- a/src/services/applicationChecks.js
+++ b/src/services/applicationChecks.js
@@ -446,6 +446,18 @@ async function checkEthereum(ip, port) {
   }
 }
 
+async function checkHavenHeight(ip, port) {
+  try {
+    const response = await axios.get(`http://${ip}:${port}/get_info`, { timeout: 5000 });
+    if (response.data.height > response.data.target_height ) {
+      return true;
+    }
+    return false;
+  } catch (error) {
+    return false;
+  }
+}
+
 module.exports = {
   checkMainFlux,
   checkKadenaApplication,
@@ -453,4 +465,5 @@ module.exports = {
   checkEthereum,
   checkFluxExplorer,
   checkCloudAtlasWebsite,
+  checkHavenHeight,
 };

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -642,6 +642,21 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
             if (isOK) {
               appIps.push(location.ip);
             }
+          } else if (app.name === 'HavenNodeMainnet') {
+            const isOK = await applicationChecks.checkHavenHeight(location.ip, 31750);
+            if (isOK) {
+              appIps.push(location.ip);
+            }
+          } else if (app.name === 'HavenNodeTestnet') {
+            const isOK = await applicationChecks.checkHavenHeight(location.ip, 32750);
+            if (isOK) {
+              appIps.push(location.ip);
+            }
+          } else if (app.name === 'HavenNodeStagenet') {
+            const isOK = await applicationChecks.checkHavenHeight(location.ip, 33750);
+            if (isOK) {
+              appIps.push(location.ip);
+            }
           } else {
             appIps.push(location.ip);
           }


### PR DESCRIPTION
Add healthcheck for Haven Protocol to be sure node is fully sync before sending traffic to it.
I've added 3 apps, because we want to deploy all networks (mainnet, stagenet & testnet on Flux)