### PR TITLE
Adding custom changes for Kadefi Money

### DIFF
--- a/src/services/applicationChecks.js
+++ b/src/services/applicationChecks.js
@@ -254,7 +254,7 @@ function kadenaCheckHeight(height) {
   const timeDifference = currentTime - baseTime;
   const blocksPassedInDifference = (timeDifference / 30000) * 20; // 20 chains with blocktime 30 seconds
   const currentBlockEstimation = baseHeight + blocksPassedInDifference;
-  const minimumAcceptedBlockHeight = currentBlockEstimation - (60 * 20); // allow being off sync for 1200 blocks; 30 mins
+  const minimumAcceptedBlockHeight = currentBlockEstimation - (60 * 310); // allow being off sync for 1200 blocks; 30 mins
   if (height > minimumAcceptedBlockHeight) {
     return true;
   }

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -170,11 +170,15 @@ function createAppsHaproxyConfig(appConfig) {
   appConfig.forEach((app) => {
     const domainUsed = app.domain.split('.').join('');
     let domainBackend = `backend ${domainUsed}backend
-  mode http
-  balance source
-  hash-type consistent
-  stick-table type ip size 1m expire 1h
-  stick on src`;
+  mode http`;
+    if (app.loadBalance) {
+      domainBackend += app.loadBalance; 
+    } else {
+      domainBackend += `\n  balance source`;
+      domainBackend += `\n  hash-type consistent`;
+      domainBackend += `\n  stick-table type ip size 1m expire 1h`;
+      domainBackend += `\n  stick on src`;
+    }
     if (app.headers) {
       // eslint-disable-next-line no-loop-func
       app.headers.forEach((header) => {


### PR DESCRIPTION
This PR adds two things.

1. Custom load balancing logic - Kadefi Money needs the Chainweb nodes to be custom load balanced (Round Robin) instead of sticky sessions. The first commit would help us with that.

2. Tweaking the Kadena Height Check - With testing manually with 3 different clusters of nodes, 1. api.chainweb.com, 2. chainweb.kaddex.com, 3. kadena2.runonflux.io, we've identified that the current kadena height check is too strict for any of those nodes to be considered successful. The new change is actively being used with Kadefi Chainweb nodes to see if they are synced and is the appropriate number for all chainweb clusters.


