### PR TITLE
feature: allow apps to use http2 connections

### DIFF
--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -329,7 +329,8 @@ function getCustomConfigs(specifications) {
     headers: false,
     loadBalance: false,
     healthcheck: [],
-    serverConfig: ''
+    serverConfig: '',
+    enableH2: false,
   };
 
   const customConfigs = {
@@ -351,6 +352,10 @@ function getCustomConfigs(specifications) {
     '33952.wp.wordpressonflux': {
       headers: ['http-request add-header X-Forwarded-Proto https'],
     },
+    "35000.KadefiMoneyDevAPI.KadefiMoneyDevAPI": {
+      ssl: true,
+      enableH2: true,
+    }
   };
 
   let mainPort = '';


### PR DESCRIPTION
https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/

Based on the documentation, the load balancer will prefer to use HTTP2 (h2) connection and also has HTTP1.1 as backup. While the `frontend` config will have this by default, the `backend` apps can configure whether they would want to use http2 or not