### PR TITLE
feat: make kadena3 Chainweb Data load balance by round robin

### DIFF
--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -348,6 +348,10 @@ function getCustomConfigs(specifications) {
       timeout: 90000,
       loadBalance: '\n  balance roundrobin',
     },
+    '31352.KadenaChainWebData.Kadena3': {
+      timeout: 90000,
+      loadBalance: '\n  balance roundrobin',
+    },
     '31352.KadefiPactAPI.KadefiMoneyPactAPI': {
       healthcheck: ['option httpchk', 'http-check send meth GET uri /health', 'http-check expect status 200'],
       serverConfig: 'inter 30s fall 2 rise 2',


### PR DESCRIPTION
While kadena3 chainweb data has not much (if at all) use right now, there are around 50 nodes currently running without handling any requests. https://kadefimoneypactapi.app.runonflux.io/fluxstatistics;up?scope=kadena3_31352 

Kadefi.money requires to use this chainweb data but running into issues as we are only hitting 1 node of Kadena3 Chainweb Data. Making this round robin would help alleviate this and make better use of the unused nodes