### PR TITLE
fix: run haproxy healthcheck on different port for kadefi

### DIFF
--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -343,10 +343,14 @@ function getCustomConfigs(specifications) {
     },
     '31350.KadefiPactAPI.KadefiMoneyPactAPI': {
       ssl: true,
+      healthcheck: ['option httpchk', 'http-check send meth GET uri /health', 'http-check expect status 200'],
+      serverConfig: 'port 31352 inter 30s fall 2 rise 2',
     },
     '31351.KadefiPactAPI.KadefiMoneyPactAPI': {
       timeout: 90000,
       loadBalance: '\n  balance roundrobin',
+      healthcheck: ['option httpchk', 'http-check send meth GET uri /health', 'http-check expect status 200'],
+      serverConfig: 'port 31352 inter 30s fall 2 rise 2',
     },
     '31352.KadenaChainWebData.Kadena3': {
       timeout: 90000,


### PR DESCRIPTION
Description of the change:

1. For each FluxApplication, there are multiple ports based on the number of services for that application, and there is a corresponding `backend` config for each port
2. These services in the same application may need to share a healthcheck endpoint running on a specific port (service in 31350 and 31351 depend on healthcheck at 31352 in this case)
3. HAProxy allows us to use a specific port for health checks by putting `check port xxxx` in the IP config.