### PR TITLE
Fix issue with isDomainPointedToThisFDM and add app whitelisting feature

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -42,5 +42,6 @@ module.exports = {
     manageapp: true,
     enabled: true,
   },
+  whiteListedApps: [], // If there's app in the array, blacklisting will be ignore
   blackListedApps: ['Kadena', 'Kadena2', 'firefox', 'firefoxtest', 'firefox2', 'apponflux', 'appononflux', 'testapponflux', 'mysqlonflux', 'mysqlfluxmysql', 'application', 'applicationapplication', 'PresearchNode*', 'FiroNode*'],
 };

--- a/src/services/domain/cert.js
+++ b/src/services/domain/cert.js
@@ -76,11 +76,18 @@ const dnsLookup = async (hostname) => {
   return result;
 };
 
-const isDomainPointedToThisFDM = async (hostname, ip) => {
+const isDomainPointedToThisFDM = async (hostname, fdmOrIP) => {
   try {
-    if (!ip) {
+    if (!fdmOrIP) {
       return false;
     }
+
+    let ip = fdmOrIP;
+    // If fdmOrIP is a hostname, we need to get the ip
+    if(!serviceHelper.stringIsIP(ip)) {
+      ip = (await dnsLookup(ip))[0].address;
+    }
+
     const dnsLookupdRecords = await dnsLookup(hostname);
     const pointedToMyIp = dnsLookupdRecords.find((record) => record.address === ip);
     if (pointedToMyIp) {
@@ -177,7 +184,7 @@ const executeCertificateOperations = async (domains, type, fdmOrIP) => {
           }
           if (!isCertificatePresent) {
             // eslint-disable-next-line no-await-in-loop
-            const domainIsPointedCorrectly = await isDomainPointedToThisFDM(appDomain);
+            const domainIsPointedCorrectly = await isDomainPointedToThisFDM(appDomain, fdmOrIP);
             if (!domainIsPointedCorrectly) {
               throw new Error(`DNS record is not pointed to this FDM for ${appDomain}, cert operations not proceeding`);
             }

--- a/src/services/domain/index.js
+++ b/src/services/domain/index.js
@@ -75,10 +75,20 @@ function getCustomDomains(app) {
 const processApplications = async (specifications, myFDMnameORip) => {
   const processedApplications = [];
   for (const appSpecs of specifications) {
-    // exclude blacklisted apps
-    if (serviceHelper.matchRule(appSpecs.name, config.blackListedApps)) {
-      // eslint-disable-next-line no-continue
-      continue;
+
+    if(config.whiteListedApps.length > 0) {
+      // exclude not whitelisted apps
+      if (!serviceHelper.matchRule(appSpecs.name, config.whiteListedApps)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+    }
+    else {
+      // exclude blacklisted apps
+      if (serviceHelper.matchRule(appSpecs.name, config.blackListedApps)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
     }
 
     log.info(`Adjusting domains and ssl for ${appSpecs.name}`);

--- a/src/services/serviceHelper.js
+++ b/src/services/serviceHelper.js
@@ -142,6 +142,11 @@ function matchRule(str, rules) {
   return false;
 }
 
+function stringIsIP(str) {
+  const regexExp = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/gi;
+  return regexExp.test(str);
+}
+
 // MongoDB functions
 async function connectMongoDb(url) {
   const connectUrl = url || mongoUrl;
@@ -238,5 +243,6 @@ module.exports = {
   createSuccessMessage,
   createWarningMessage,
   createErrorMessage,
+  stringIsIP,
   matchRule,
 };


### PR DESCRIPTION
fdmOrIP was not passed to **isDomainPointedToThisFDM** and **isDomainPointedToThisFDM** was always returning false.

fdmOrIP can be an IP or a hostname. If it's not an IP, I call DNS lookup to get the IP address of the FDM.

I also add a whitelisting app feature to only load apps that we want to load in FDM.