### PR TITLE
Update checks.js

### DIFF
--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -442,7 +442,16 @@ async function checkFuse(ip, port) {
     const node = `http://${ip}:${port}`;
     const provider = new ethers.providers.JsonRpcProvider(node);
     const isSyncing = await provider.send("eth_syncing");
-    return !isSyncing;
+    if (isSyncing) {
+      return false;
+    }
+    const blockNum = await provider.getBlockNumber();
+    const providerB = new ethers.providers.JsonRpcProvider('https://fuse-mainnet.chainstacklabs.com');
+    const blockNumB = await providerB.getBlockNumber();
+    if (blockNumB - blockNum > 1) {
+      return false;
+    }
+    return true;
   } catch (error) {
     return false;
   }


### PR DESCRIPTION
added a 2nd health check to the Fuse application to compare the Block Number with the Chainstack RPC Node. Tested locally @TheTrunk 