### PR TITLE
Health check for WordPress apps

### DIFF
--- a/src/services/application/custom.js
+++ b/src/services/application/custom.js
@@ -12,6 +12,7 @@ function getCustomConfigs(specifications) {
 
   if (specifications.name.toLowerCase().includes('wordpress')) {
     defaultConfig.headers = ['http-request add-header X-Forwarded-Proto https'];
+    defaultConfig.healthcheck = ['option httpchk', 'http-check send meth GET uri /'];
   }
 
   const customConfigs = {


### PR DESCRIPTION
WordPress returns 3xx in some cases to redirect to the correct domain, This method accepts 2xx and 3xx status codes.