### PR TITLE
Update rsync

### DIFF
--- a/deployment/dev_hosts.ini
+++ b/deployment/dev_hosts.ini
@@ -1,0 +1,5 @@
+[app2_fdm_servers]
+fdm_dev_1 ansible_host=172.16.32.10
+fdm_dev_2 ansible_host=172.16.32.11
+
+[app_fdm_servers]

--- a/deployment/fdm_rsync_setup.yml
+++ b/deployment/fdm_rsync_setup.yml
@@ -1,0 +1,93 @@
+---
+- name: Deploy rsync user and setup ssh for FDM servers
+  hosts: "{{ 'app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers' }}"
+  become: yes
+
+  vars:
+    thirty_days_in_s: "{{ 86400 * 30 }}"
+    homedir: /home/rsync
+    keygen_cmd: /usr/bin/ssh-keygen -t ed25519 -N "" -C "{{ inventory_hostname }}" -f
+    current_keyfile: "{{ homedir }}/.ssh/id_ed25519"
+    next_keyfile: "{{ homedir }}/.ssh/id_ed25519_next"
+
+  tasks:
+    - name: Ensure group "ssl-cert" exists
+      ansible.builtin.group:
+        state: present
+        name: ssl-cert
+
+    # removed the key management here, if it gets deleted,
+    # this would recreate it, but it wouldn't propagate
+    - name: Ensure "rsync" user is present
+      ansible.builtin.user:
+        state: present
+        name: rsync
+        password: "!"
+        system: true
+        # generate_ssh_key: yes
+        # ssh_key_file: "{{ current_keyfile }}"
+        # ssh_key_type: ed25519
+        groups: ssl-cert
+        append: yes
+
+    - name: Get last modified time of id_ed25519_current
+      ansible.builtin.stat:
+        path: "{{ current_keyfile }}"
+      register: key_file
+
+    - name: Create keys
+      include_tasks: ./keys/create.yml
+      when: not key_file.stat.exists
+
+    - name: Rotate keys
+      include_tasks: ./keys/rotate.yml
+      when: >
+        key_file.stat.mtime is defined and
+        key_file.stat.mtime | int + thirty_days_in_s | int <
+        ansible_date_time.epoch | int
+
+- name: Store ssh server pubkeys of relevant hosts in known_hosts file
+  hosts: localhost
+  connection: local
+
+  vars:
+    ssh_known_hosts_command: "ssh-keyscan -t ed25519 -T 10"
+    fdm_server_group: "{{ 'app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers' }}"
+    fdm_servers: "{{ groups[fdm_server_group] | map('extract', hostvars, ['ansible_host']) }}"
+
+  tasks:
+    - name: Scan fdm_servers ssh public-key
+      ansible.builtin.shell: "{{ ssh_known_hosts_command }} {{ item }}"
+      with_items: "{{ fdm_servers }}"
+      register: ssh_known_host_data
+      changed_when: False
+
+    - set_fact:
+        known_hosts_file={{ ssh_known_host_data.results }}
+
+- name: Update known hosts for FDM servers
+  hosts: "{{ 'app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers' }}"
+  become: yes
+
+  vars:
+    homedir: /home/rsync
+    ssh_known_hosts_file: "{{ homedir }}/.ssh/known_hosts"
+
+  tasks:
+    - name: Ensure known_hosts exists and is owned by rsync
+      ansible.builtin.file:
+        name: "{{ ssh_known_hosts_file }}"
+        owner: rsync
+        group: rsync
+        state: touch
+        access_time: preserve
+        modification_time: preserve
+
+    - name: fdm_servers update known hosts
+      no_log: True
+      ansible.builtin.known_hosts:
+        name: "{{ item.item }}"
+        key: "{{ item.stdout }}"
+        path: "{{ ssh_known_hosts_file }}"
+      when: ansible_host != item.item
+      loop: "{{ hostvars['localhost']['known_hosts_file'] }}"

--- a/deployment/fdm_setup.yml
+++ b/deployment/fdm_setup.yml
@@ -16,7 +16,7 @@
         repo: "deb [signed-by=/etc/apt/keyrings/mongo.asc] https://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/6.0 multiverse"
         state: present
         filename: mongodb-org-6.0
-    
+
     - name: Update apt package list
       ansible.builtin.apt:
         update_cache: yes
@@ -35,7 +35,13 @@
           - build-essential
           - libssl-dev
           - curl
+          - python3-pip
         state: present
+
+    - name: Install jc via python
+      ansible.builtin.pip:
+        name: jc
+        version: 1.25.2
 
     - name: Install Node.js 18.x repository
       shell: "curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -"
@@ -48,13 +54,13 @@
 
     - name: Install PM2 globally using NPM
       command: npm install -g pm2
-      
+
     - name: Enable and start MongoDB service
       ansible.builtin.systemd:
         name: mongod
         state: started
         enabled: yes
-      
+
     - name: Ensure directory exists
       ansible.builtin.file:
         path: /etc/ssl/fluxapps
@@ -70,7 +76,7 @@
         owner: root
         group: root
         mode: '0775'
-  
+
     - name: Copy new certbot-cron
       ansible.builtin.copy:
         src: certbot-cron
@@ -78,7 +84,7 @@
         owner: root
         group: root
         mode: '0644'
-    
+
     - name: Clone FDM
       ansible.builtin.git:
         repo: https://github.com/RunOnFlux/flux-domain-manager.git
@@ -125,7 +131,7 @@
       command: npm install
       args:
         chdir: flux-domain-manager
-    
+
     - name: Install Dependencies CDM
       command: npm install
       args:

--- a/deployment/keys/create.yml
+++ b/deployment/keys/create.yml
@@ -1,0 +1,37 @@
+---
+- name: Generate current ed25519 keypair
+  ansible.builtin.command: "{{ keygen_cmd }} {{ current_keyfile }}"
+
+- name: Ensure rsync ownership of keys
+  ansible.builtin.file:
+    name: "{{ homedir }}/.ssh"
+    state: directory
+    recurse: true
+    owner: rsync
+    group: rsync
+
+- name: "Fetch the content of {{ current_keyfile }}.pub"
+  shell: "cat {{ current_keyfile }}.pub"
+  register: ssh_key_content
+
+- name: "Remove any other authorized_keys for {{ inventory_hostname }}"
+  ansible.builtin.lineinfile:
+    path: "{{ homedir }}/.ssh/authorized_keys"
+    create: yes
+    state: absent
+    regexp: "^ssh-ed25519.*{{ inventory_hostname }}"
+  delegate_to: "{{ item }}"
+  when: inventory_hostname != item
+  loop: "{{ groups['app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers'] }}"
+
+- name: "Append {{ current_keyfile }}.pub to authorized_keys on remote hosts"
+  ansible.builtin.lineinfile:
+    path: "{{ homedir }}/.ssh/authorized_keys"
+    line: "{{ ssh_key_content.stdout }}"
+    create: yes
+    state: present
+    owner: rsync
+    group: rsync
+  delegate_to: "{{ item }}"
+  when: inventory_hostname != item
+  loop: "{{ groups['app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers'] }}"

--- a/deployment/keys/rotate.yml
+++ b/deployment/keys/rotate.yml
@@ -1,0 +1,67 @@
+---
+- name: Generate next ed25519 keypair
+  ansible.builtin.command: "{{ keygen_cmd }} {{ next_keyfile }}"
+
+- name: "Fetch the content of {{ current_keyfile }}.pub"
+  shell: "cat {{ current_keyfile }}.pub"
+  register: ssh_current_key_content
+
+- name: "Fetch the content of {{ next_keyfile }}.pub"
+  shell: "cat {{ next_keyfile }}.pub"
+  register: ssh_next_key_content
+
+- name: "Append {{ next_keyfile }}.pub to authorized_keys on remote hosts"
+  ansible.builtin.lineinfile:
+    path: "{{ homedir }}/.ssh/authorized_keys"
+    line: "{{ ssh_next_key_content.stdout }}"
+    create: yes
+    state: present
+    owner: rsync
+    group: rsync
+  delegate_to: "{{ item }}"
+  when: inventory_hostname != item
+  loop: "{{ groups['app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers'] }}"
+
+- name: Ensure rsync ownership of keys
+  ansible.builtin.file:
+    name: "{{ homedir }}/.ssh"
+    state: directory
+    recurse: true
+    owner: rsync
+    group: rsync
+
+- name: "Copy {{ next_keyfile }} to current"
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ next_keyfile }}"
+    dest: "{{ current_keyfile }}"
+    force: true
+
+- name: "Copy {{ next_keyfile }}.pub to current"
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ next_keyfile }}.pub"
+    dest: "{{ current_keyfile }}.pub"
+    force: true
+
+- name: "Remove {{ next_keyfile }}"
+  ansible.builtin.file:
+    name: "{{ next_keyfile }}"
+    state: absent
+
+- name: "Remove {{ next_keyfile }}.pub"
+  ansible.builtin.file:
+    name: "{{ next_keyfile }}.pub"
+    state: absent
+
+- name: "Remove {{ current_keyfile }}.pub from authorized_keys on remote hosts"
+  ansible.builtin.lineinfile:
+    path: "{{ homedir }}/.ssh/authorized_keys"
+    line: "{{ ssh_current_key_content.stdout }}"
+    create: yes
+    state: absent
+    owner: rsync
+    group: rsync
+  delegate_to: "{{ item }}"
+  when: inventory_hostname != item
+  loop: "{{ groups['app_fdm_servers' if DEPLOY_ENV == 'production' else 'app2_fdm_servers'] }}"

--- a/src/services/rsync/index.js
+++ b/src/services/rsync/index.js
@@ -1,21 +1,22 @@
 const cmd = require('node-cmd');
 const util = require('util');
 const { getHostsToRsync } = require('./config');
+const log = require('../../lib/log');
 
 const cmdAsync = util.promisify(cmd.run);
 
 async function startCertRsync() {
-  console.log('starting r sync');
+  log.info('starting rsync');
   const ips = getHostsToRsync();
   try {
     // eslint-disable-next-line no-restricted-syntax
     for (const ip of ips) {
       // eslint-disable-next-line no-await-in-loop
-      await cmdAsync(`rsync -avh -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress /etc/ssl/fluxapps/ ${ip}:/etc/ssl/fluxapps/`);
-      console.log(`Certs sent to ${ip}`);
+      await cmdAsync(`rsync -au -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" /etc/ssl/fluxapps/ ${ip}:/etc/ssl/fluxapps/`);
+      log.info(`Certs sent to ${ip}`);
     }
   } catch (error) {
-    console.log(error);
+    log.info(error);
   }
 }
 


### PR DESCRIPTION
I have tested this on a single CDM. Working

* Adds future setup for rsync. (not used currently) This does thie following:
* Adds a dev_hosts.ini file, unused at the moment, but will use this on dev branch. hosts were supposed to be x.x.x.x but if people want to use this - they can change the hosts. (I'm runing against a couple of my local hosts for testing)
  * Creates ssl-cert group.
  * Creates rsync user and adds to ssl-cert group.
  * Creates ed25519 key if it doesn't exist.
  * If ed25519 key does exist and is older than 30 days, it rotates it.
  * Sets up known_hosts so we can reenable known host key check via rsync (it's currently disabled).
  * Copies pubkey to all hosts in the same group.

* Adds apt package so we can install python packages.
* Adds "jc" python package - this will be used in the future to parse rsync output as json.
* Fixes rsync command - add the -u option to only update if file is older, remove unnecessary -vh --progress options (these are for if a human was viewing the output)
* Add logging to rsync

I have rewritten the rsync file logic - but will leave all those changes until I've completed other fdm work.

Note regarding the key rotation. This is just good security hygiene. The way it is engineered, there will be 0 outage for rsync when the keys are rotated.