### PR TITLE
Feature: Enable preserve in cookie config stanza

### DIFF
--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -213,7 +213,7 @@ backend ${domainUsed}backend
     domainBackend += app.loadBalance;
   } else if (mode !== 'tcp') {
     domainBackend += '\n  balance roundrobin';
-    domainBackend += '\n  cookie FDMSERVERID insert indirect nocache maxlife 8h';
+    domainBackend += '\n  cookie FDMSERVERID insert preserve indirect nocache maxlife 8h';
   }
   if (app.headers) {
     // eslint-disable-next-line no-loop-func


### PR DESCRIPTION
This change allows fluxapps to set their own persistence cookie.

Behaviour before this change:

if the `FDMSERVERID` cookie was set by an app, FDM would strip it and replace it with it's own.

Behaviour after this change:

if the `FDMSERVERID` cookie is set by an app, FDM will "preserve" it. If it is missing, FDM will set it.

This allows for new app usecases. For example, an app may have a frontend and a backend and may want to influence what frontend server get used from the backend, or a backend may want to remove itself from the session persistence by setting the cookie to blank (or another server)

This is currently running on `fdm-usa-2-1` and `fdm-fn-2-1` (manually configured).

Tested and working as expected.