### PR TITLE
Update custom.js - Add TCP for wordpress operator

### DIFF
--- a/src/services/application/custom.js
+++ b/src/services/application/custom.js
@@ -101,6 +101,9 @@ function getCustomConfigs(specifications, isGsyncthingApp) {
     '34443.friendica.friendica': {
       ssl: true,
     },
+    '34328.wordpress1677413615318.wordpress': {
+       mode: 'tcp',
+    },
   };
 
   let mainPort = '';


### PR DESCRIPTION
Port 34328 will now will have TCP forwarding for wordpress apps