### PR TITLE
Update custom.js - Add SSL for WhoogleFlux

### DIFF
--- a/src/services/application/custom.js
+++ b/src/services/application/custom.js
@@ -111,6 +111,9 @@ function getCustomConfigs(specifications, isGsyncthingApp) {
     '38888.nginx.owncloudssl': {
       ssl: true,
     },
+    '38443.nginx.whoogleflux': {
+      ssl: true,
+    },
   };
 
   let mainPort = '';


### PR DESCRIPTION
Add SSL flag for WhoogleFlux application, nginx container, and port 38443