### PR TITLE
Update custom.js - Add SSL true for trilium apps

### DIFF
--- a/src/services/application/custom.js
+++ b/src/services/application/custom.js
@@ -20,6 +20,11 @@ function getCustomConfigs(specifications, isGsyncthingApp) {
   if (specifications.name.toLowerCase().includes('bittensor')) {
     defaultConfig.mode = 'tcp';
   }
+
+  if (specifications.name.toLowerCase().includes('trilium')) {
+    defaultConfig.ssl = true;
+  }
+  
   if (isGsyncthingApp) {
     defaultConfig.mode = 'tcp';
     defaultConfig.check = false;


### PR DESCRIPTION
Set SSL true for default config if the app name includes trilium.