### PR TITLE
adjust wp health check

### DIFF
--- a/src/services/application/custom.js
+++ b/src/services/application/custom.js
@@ -70,7 +70,10 @@ function getCustomConfigs(specifications, isGsyncthingApp) {
       serverConfig: 'inter 30s fall 2 rise 2',
     },
     '33952.wp.wordpressonflux': {
+      timeout: 3000,
       headers: ['http-request add-header X-Forwarded-Proto https'],
+      healthcheck: ['option httpchk', 'http-check send meth GET uri /', 'http-check expect status 200'],
+      serverConfig: 'inter 3s fall 2 rise 1',
     },
     '36117.KadefiMoneyUDFServer.KadefiMoneyUDFServer': {
       healthcheck: ['option httpchk', 'http-check send meth GET uri /health', 'http-check expect status 200'],

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -217,9 +217,7 @@ backend ${domainUsed}backend
     domainBackend += app.loadBalance;
   } else if (mode !== 'tcp') {
     domainBackend += '\n  balance roundrobin';
-    if (app.isRdata || app.ips.length <= 1) {
-      domainBackend += '\n  cookie FDMSERVERID insert preserve indirect nocache maxlife 1s';
-    } else {
+    if (!(app.isRdata || app.ips.length <= 1)) {
       domainBackend += '\n  cookie FDMSERVERID insert preserve indirect nocache maxlife 8h';
     }
   }


### PR DESCRIPTION
Removes FDMSERVERID cookie for R apps
Adjusts health check configs for WP apps:
- Set timeout to 3s
- Health check every 3s
- Health check needs to fail 2 times for a node to be considered down