### PR TITLE
FDM v8 enterprise spec decryption

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,13 +5,12 @@ module.exports = {
     node: true,
     mocha: true,
   },
-  extends: [
-    'airbnb-base',
-  ],
+  extends: ['airbnb-base'],
   rules: {
     'max-len': [
       'error',
       {
+        // this should be 120 absolute max
         code: 300,
         ignoreUrls: true,
         ignoreTrailingComments: true,
@@ -19,23 +18,16 @@ module.exports = {
     ],
     'no-console': 'off',
     'default-param-last': 'off',
-    'import/extensions': [
-      'error',
-      'never',
-    ],
-    'linebreak-style': [
-      'error',
-      'unix',
-    ],
+    'import/extensions': ['error', 'never'],
+    'linebreak-style': ['error', 'unix'],
   },
   parserOptions: {
     parser: 'babel-eslint',
+    ecmaVersion: 'latest',
   },
   overrides: [
     {
-      files: [
-        '**/__tests__/*.{j,t}s?(x)',
-      ],
+      files: ['**/__tests__/*.{j,t}s?(x)'],
       env: {
         mocha: true,
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "testcloudflare": "mocha tests --timeout 10000 --grep 'cloudflareService'"
   },
   "dependencies": {
+    "@isaacs/ttlcache": "^1.4.1",
     "apicache": "^1.6.3",
     "axios": "^1.10.0",
     "chai": "^4.3.6",

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -34,7 +34,9 @@ function writeToFile(filepath, args) {
 
 function debug(args) {
   try {
-    console.log(args);
+    // we are already logging to file. Don't log to console, as it hides
+    // all the actual calls to console.log
+    // console.log(args);
     // write to file
     const filepath = `${homeDirPath}debug.log`;
     writeToFile(filepath, args);

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -132,7 +132,7 @@ async function isVersionOK(ip, port) {
   try {
     const url = `http://${ip}:${port}/flux/info`;
     const response = await serviceHelper.httpGetRequest(url, timeout);
-    const version = response.data.data.flux.version;
+    const { version } = response.data.data.flux;
     if (minVersionSatisfy(version, '6.3.0')) {
       if (response.data.data.flux.development === 'false' || !response.data.data.flux.development) {
         return true;
@@ -151,7 +151,7 @@ async function isArcaneOS(ip, port) {
     const url = `http://${ip}:${port}/flux/isarcaneos`;
     const response = await serviceHelper.httpGetRequest(url, timeout);
     if (response.data.data) {
-      return true
+      return true;
     }
     return false;
   } catch (error) {
@@ -557,7 +557,7 @@ async function extendedInsightTest(url, blockUlr, txUrl) {
   const adjustedUrlTx = txUrl + txid;
   const responseC = await serviceHelper.httpGetRequest(adjustedUrlTx, 8888);
   if (responseC.data.confirmations < -2) {
-    return false
+    return false;
   }
   return true;
 }
@@ -596,10 +596,10 @@ async function checkHavenHeight(ip, port) {
 async function checkHavenRPC(ip, port) {
   try {
     const data = {
-      "jsonrpc": "2.0",
-      "id": "0",
-      "method": "get_last_block_header"
-    }
+      jsonrpc: '2.0',
+      id: '0',
+      method: 'get_last_block_header',
+    };
     await serviceHelper.httpPostRequest(`http://${ip}:${port}/json_rpc`, data, 1500);
     // if code 200 all ok
     return true;
@@ -664,7 +664,8 @@ async function checkBlockBook(ip, port, appsname) {
     let coin = appsname.replace('blockbook', '');
     coin = coin.replace(/\d+/g, '');
     const index = coinList.indexOf(coin);
-    let response1, response2;
+    let response1; let
+      response2;
     const agent = new https.Agent({
       rejectUnauthorized: false,
     });
@@ -800,7 +801,7 @@ async function checkMinecraft(ip, port) {
       host: ip,
       port,
       attemptTimeout: 5000,
-      maxRetries: 3
+      maxRetries: 3,
     });
     return true;
   } catch (error) {
@@ -816,7 +817,7 @@ async function checkPalworld(ip, port) {
       host: ip,
       port,
       attemptTimeout: 5000,
-      maxRetries: 3
+      maxRetries: 3,
     });
     return true;
   } catch (error) {
@@ -884,32 +885,32 @@ async function checkAppRunning(url, appName) {
 function applicationWithChecks(app) {
   if (generalWebsiteApps.includes(app.name)) {
     return true;
-  } else if (app.name === 'explorer') {
+  } if (app.name === 'explorer') {
     return true;
-  } else if (app.name === 'bitcoinnode' || app.name === 'bitcoinnodetestnet' || app.name === 'bitcoinnodesignet') {
+  } if (app.name === 'bitcoinnode' || app.name === 'bitcoinnodetestnet' || app.name === 'bitcoinnodesignet') {
     return true;
-  } else if (app.name === 'HavenNodeMainnet') {
+  } if (app.name === 'HavenNodeMainnet') {
     return true;
-  } else if (app.name === 'HavenNodeTestnet') {
+  } if (app.name === 'HavenNodeTestnet') {
     return true;
-  } else if (app.name === 'HavenNodeStagenet') {
+  } if (app.name === 'HavenNodeStagenet') {
     return true;
-  } else if (app.name.startsWith('blockbook')) {
+  } if (app.name.startsWith('blockbook')) {
     return true;
-  } else if (app.name.startsWith('AlgorandRPC')) {
+  } if (app.name.startsWith('AlgorandRPC')) {
     return true;
-  } else if (app.name.toLowerCase().includes('bittensor')) {
+  } if (app.name.toLowerCase().includes('bittensor')) {
     return true;
-  } else if (app.name === 'alphexplorer') {
+  } if (app.name === 'alphexplorer') {
     return true;
-  } else if (app.name === 'ergo') {
+  } if (app.name === 'ergo') {
     return true;
-  } else {
-    const matchIndex = ethersList.findIndex((eApp) => app.name.startsWith(eApp.name));
-    if (matchIndex > -1) {
-      return true;
-    }
   }
+  const matchIndex = ethersList.findIndex((eApp) => app.name.startsWith(eApp.name));
+  if (matchIndex > -1) {
+    return true;
+  }
+
   return false;
 }
 
@@ -937,7 +938,7 @@ async function checkApplication(app, ip) {
       isOK = await checkHavenRPC(ip.split(':')[0], 33750);
     }
   } else if (app.name.startsWith('blockbook')) {
-    isOK = await checkBlockBook(ip.includes('[') ? ip.split(']')[0] + ']' : ip.split(':')[0], ip.includes(']:') ? ip.split(']:')[1] : app.compose[0].ports[0], app.name);
+    isOK = await checkBlockBook(ip.includes('[') ? `${ip.split(']')[0]}]` : ip.split(':')[0], ip.includes(']:') ? ip.split(']:')[1] : app.compose[0].ports[0], app.name);
   } else if (app.name.startsWith('AlgorandRPC')) {
     isOK = await checkAlgorand(ip.split(':')[0], app.compose[0].ports[1]);
   } else if (app.name.toLowerCase().includes('bittensor')) {

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -492,8 +492,7 @@ async function checkALPHexplorer(ip, port) {
     }
     return false;
   } catch (error) {
-    log.info('e');
-    log.info(error);
+    log.info(`Failed to check ALPH explorer: ${error.message}`);
     return false;
   }
 }
@@ -714,7 +713,7 @@ async function checkAlgorand(ip, port) {
   };
   try {
     const status = await axios.get(`http://${ip}:${port}/health`, axiosConfig);
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-lin:e no-restricted-syntax
     if (status.data.isSynced === true) {
       return true;
     }

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -703,7 +703,7 @@ async function checkBlockBook(ip, port, appsname) {
     log.error(`Bad IP ${ip}:${port} blockbook ${appsname}`);
     return false;
   } catch (error) {
-    log.error(error);
+    log.error(`Error checking blockbook endpoint: ${ip}:${port} ${error.message}`);
     return false;
   }
 }

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -133,7 +133,7 @@ async function isVersionOK(ip, port) {
     const url = `http://${ip}:${port}/flux/info`;
     const response = await serviceHelper.httpGetRequest(url, timeout);
     const { version } = response.data.data.flux;
-    if (minVersionSatisfy(version, '6.3.0')) {
+    if (minVersionSatisfy(version, '6.3.1')) {
       if (response.data.data.flux.development === 'false' || !response.data.data.flux.development) {
         return true;
       }

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -663,8 +663,8 @@ async function checkBlockBook(ip, port, appsname) {
     let coin = appsname.replace('blockbook', '');
     coin = coin.replace(/\d+/g, '');
     const index = coinList.indexOf(coin);
-    let response1; let
-      response2;
+    let response1;
+    let response2;
     const agent = new https.Agent({
       rejectUnauthorized: false,
     });
@@ -713,7 +713,6 @@ async function checkAlgorand(ip, port) {
   };
   try {
     const status = await axios.get(`http://${ip}:${port}/health`, axiosConfig);
-    // eslint-disable-next-lin:e no-restricted-syntax
     if (status.data.isSynced === true) {
       return true;
     }

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -766,10 +766,11 @@ async function getBlockchainInfo(host, port, username, password) {
         password,
       },
     });
-    console.log(response.data);
+    // removed due to excessive console logs
+    // console.log(response.data);
     return response.data.result;
   } catch (error) {
-    console.log(error);
+    console.log(`getBlockchainInfo error: ${error.message}`);
     return false;
   }
 }

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -132,7 +132,7 @@ async function isVersionOK(ip, port) {
   try {
     const url = `http://${ip}:${port}/flux/info`;
     const response = await serviceHelper.httpGetRequest(url, timeout);
-    const { version } = response.data.data.flux;
+    const version = response.data.data.flux.version;
     if (minVersionSatisfy(version, '6.3.1')) {
       if (response.data.data.flux.development === 'false' || !response.data.data.flux.development) {
         return true;

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -963,8 +963,7 @@ setInterval(async () => {
       currentFluxBlockheight = height;
     }
   } catch (error) {
-    log.error(error);
-    log.error('ERROR OBTAINING FLUX HEIGHT');
+    log.error(`Error obtaining flux height: ${error.message}`);
   }
 }, 120 * 1000);
 

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -135,7 +135,8 @@ async function generateAndReplaceMainHaproxyConfig() {
         uiPrimary,
         apiPrimary,
       );
-      console.log(hc);
+      // stop logging the entire ha proxy config to console
+      // console.log(hc);
       const dataToWrite = hc;
       // test haproxy config
       const successRestart = await haproxyTemplate.restartProxy(dataToWrite);

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1014,10 +1014,18 @@ async function startAppDataFetcher() {
     async (specs) => {
       unifiedAppsDomains = specs.appFqdns;
 
-      if (configQueued && configRunning) return;
+      if (configQueued && configRunning) {
+        console.log('appSpecsUpdated event received, while '
+          + 'an update already queued, skipping');
+
+        return;
+      }
 
       if (configRunning) {
+        console.log('appSpecsUpdated event received while an '
+          + 'update is running. Queueing next update.');
         configQueued = true;
+
         return;
       }
 
@@ -1035,8 +1043,8 @@ async function startAppDataFetcher() {
     permanentMessages = permMessages;
   });
 
-  // We just run this once prior the appSpec loop so the permanent messages are
-  // populated first
+  // We just run this once prior to the appSpec loop so the permanent messages
+  // are populated first
   await dataFetcher.permMessageRunner();
   dataFetcher.startAppSpecLoop();
   dataFetcher.startPermMessagesLoop();

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -184,7 +184,8 @@ async function generateAndReplaceMainHaproxyConfig() {
       uiPrimary,
       apiPrimary,
     );
-    console.log(hc);
+    // stop logging entire ha proxy config to console
+    // console.log(hc);
     const dataToWrite = hc;
     // test haproxy config
     const successRestart = await haproxyTemplate.restartProxy(dataToWrite);
@@ -288,7 +289,8 @@ async function updateHaproxy(haproxyAppsConfig) {
     }
     updateHaproxyRunning = true;
     const hc = await haproxyTemplate.createAppsHaproxyConfig(haproxyAppsConfig);
-    console.log(hc);
+    // stop logging entire ha proxy config to console
+    // console.log(hc);
     const dataToWrite = hc;
     // test haproxy config
     const successRestart = await haproxyTemplate.restartProxy(dataToWrite);
@@ -1043,7 +1045,7 @@ async function startAppDataFetcher() {
 // services run every 6 mins
 function initializeServices() {
   myIP = ipService.localIP();
-  console.log(myIP);
+  console.log(`public IP: ${myIP}`);
   if (config.domainAppType === 'CNAME') {
     myFDMnameORip = config.fdmAppDomain;
   } else {

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1078,6 +1078,9 @@ async function start() {
       permanentMessages = permMessages;
     });
 
+    // We just run this once prior the appSpec loop so the permanent messages are
+    // populated first
+    await dataFetcher.permMessageRunner();
     dataFetcher.startAppSpecLoop();
     dataFetcher.startPermMessagesLoop();
   }

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1062,8 +1062,8 @@ async function start() {
       keyPath: '/root/fdm-arcane-specs/fdm-eu-2-1.key',
       certPath: '/root/fdm-arcane-specs/fdm-eu-2-1.pem',
       caPath: '/root/fdm-arcane-specs/ca.pem',
-      fluxApiBasePath: 'https://api.runonflux.io/',
-      sasApiBasePath: 'https://10.100.0.170/api/',
+      fluxApiBaseUrl: 'https://api.runonflux.io/',
+      sasApiBaseUrl: 'https://10.100.0.170/api/',
     });
 
     dataFetcher.on(
@@ -1078,8 +1078,8 @@ async function start() {
       permanentMessages = permMessages;
     });
 
-    setImmediate(dataFetcher.startAppSpecLoop);
-    setImmediate(dataFetcher.startPermMessagesLoop);
+    dataFetcher.startAppSpecLoop();
+    dataFetcher.startPermMessagesLoop();
   }
 
   try {

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1096,12 +1096,11 @@ function initializeServices() {
 
 async function start() {
   if (!dataFetcher) {
-    // symlink these to the same place on every fdm
-    // these paths are just dev at the moment
+    // these are symlinked to the correct key / pem on every box
     dataFetcher = new FdmDataFetcher({
-      keyPath: '/root/fdm-arcane-specs/fdm-eu-2-1.key',
-      certPath: '/root/fdm-arcane-specs/fdm-eu-2-1.pem',
-      caPath: '/root/fdm-arcane-specs/ca.pem',
+      keyPath: '/etc/ssl/private/fdm-arcane.key',
+      certPath: '/etc/ssl/certs/fdm-arcane.pem',
+      caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
       fluxApiBaseUrl: 'https://api.runonflux.io/',
       sasApiBaseUrl: 'https://10.100.0.170/api/',
     });

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -171,11 +171,10 @@ class FdmDataFetcher extends EventEmitter {
     components.forEach((comp) => {
       for (let i = 0; i < comp.ports.length; i += 1) {
         const portDomains = comp.domains[i].split(',');
+        // strip http(s):// and also bad characters
         portDomains.forEach((portDomain) => {
           fqdns.push(portDomain
-            .replace('https://', '')
-            .replace('http://', '')
-            .replace(/[&/\\#,+()$~%'":*?<>{}]/g, '')
+            .replace(/https?:\/\/|[&/\\#,+()$~%'":*?<>{}]/g, '')
             .toLowerCase());
         });
       }

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -58,7 +58,7 @@ class FdmDataFetcher extends EventEmitter {
       url: 'apps/permanentmessages',
       options: {
         decompress: true,
-        headers: { 'Accept-Encoding': 'gzip, deflate, br, zstd' },
+        headers: { 'Accept-Encoding': 'gzip, compress, deflate, br' },
       },
       sha: '',
       etag: '',

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -776,9 +776,9 @@ class FdmDataFetcher extends EventEmitter {
 
 async function main() {
   const specFetcher = new FdmDataFetcher({
-    keyPath: '/root/fdm-arcane-specs/fdm-eu-2-1.key',
-    certPath: '/root/fdm-arcane-specs/fdm-eu-2-1.pem',
-    caPath: '/root/fdm-arcane-specs/ca.pem',
+    keyPath: '/etc/ssl/private/fdm-arcane.key',
+    certPath: '/etc/ssl/certs/fdm-arcane.pem',
+    caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
     fluxApiBaseUrl: 'https://api.runonflux.io/',
     sasApiBaseUrl: 'https://10.100.0.170/api/',
   });

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -190,6 +190,12 @@ class FdmDataFetcher extends EventEmitter {
     await new Promise((r) => { setTimeout(r, ms); });
   }
 
+  static timestamp() {
+    const formattedTime = new Date().toISOString().replace(/\.\d+Z?/, '');
+
+    return formattedTime;
+  }
+
   /**
    * Decrypts content with aes key
    * @param {string} appName application name.
@@ -281,7 +287,10 @@ class FdmDataFetcher extends EventEmitter {
 
     const cacheSpec = this.#cache.get(spec.hash);
 
-    if (cacheSpec) return cacheSpec;
+    if (cacheSpec) {
+      console.log(`Encrypted App spec: ${spec.name}, found in cache, no need to fetch`);
+      return cacheSpec;
+    }
 
     let originalOwner = this.#cache.get(spec.name);
     let ownerAttempts = 0;
@@ -321,6 +330,7 @@ class FdmDataFetcher extends EventEmitter {
         break;
       }
 
+      console.log(`Owner fetch for: ${spec.name} failed, retrying in 3 seconds`);
       ownerAttempts += 1;
       // eslint-disable-next-line no-await-in-loop
       await FdmDataFetcher.sleep(3_000);
@@ -358,6 +368,8 @@ class FdmDataFetcher extends EventEmitter {
       // is 30 seconds. So at max we would wait 2 cycles if nginx is down, and it
       // needs to be taken out of the server pool
       if (!response) {
+        console.log(`Decrypt AES key call for: ${spec.name} failed, retrying in 16 seconds`);
+
         decryptKeyAttempts += 1;
         // eslint-disable-next-line no-await-in-loop
         await FdmDataFetcher.sleep(16_000);
@@ -386,6 +398,7 @@ class FdmDataFetcher extends EventEmitter {
 
       // shouldn't end up here
 
+      console.log(`Base64AesKey not found for: ${spec.name}, retrying in 16 seconds`);
       decryptKeyAttempts += 1;
       // eslint-disable-next-line no-await-in-loop
       await FdmDataFetcher.sleep(16_000);
@@ -479,6 +492,7 @@ class FdmDataFetcher extends EventEmitter {
       etag,
       sameEtag: etag === store.etag,
       maxAgeMs,
+      timestamp: FdmDataFetcher.timestamp(),
     };
 
     console.log(logger);
@@ -590,6 +604,7 @@ class FdmDataFetcher extends EventEmitter {
       etag,
       specSize: payload ? payload.length : 0,
       sleepTimeMs,
+      timestamp: FdmDataFetcher.timestamp(),
     };
     console.log(logger);
 
@@ -633,6 +648,7 @@ class FdmDataFetcher extends EventEmitter {
       etag,
       specSize: payload ? payload.length : 0,
       sleepTimeMs,
+      timestamp: FdmDataFetcher.timestamp(),
     };
     console.log(logger);
 

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -524,6 +524,9 @@ class FdmDataFetcher extends EventEmitter {
 
     const specMapper = (_specs) => {
       _specs.forEach((spec) => {
+        // this can happen if we give up trying to get owner or sas key etc
+        if (!spec) return;
+
         const { version, enterprise } = spec;
 
         const isEnterprise = Boolean(version >= 8 && enterprise);

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -595,7 +595,9 @@ class FdmDataFetcher extends EventEmitter {
     }
 
     const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
-    const sleepTimeMs = Math.max(0, maxAgeMs - elapsedMs);
+    // add a one second overlay here. This stops retries when the max-age is
+    // at 0.
+    const sleepTimeMs = Math.max(1_000, maxAgeMs - elapsedMs + 1_000);
 
     const logger = {
       name: 'permMessages',
@@ -639,7 +641,9 @@ class FdmDataFetcher extends EventEmitter {
     }
 
     const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
-    const sleepTimeMs = Math.max(0, maxAgeMs - elapsedMs);
+    // add a one second overlay here. This stops retries when the max-age is
+    // at 0.
+    const sleepTimeMs = Math.max(1_000, maxAgeMs - elapsedMs + 1_000);
 
     const logger = {
       name: 'globalAppSpecs',

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -6,6 +6,7 @@ const url = require('node:url');
 
 const axios = require('axios');
 
+// const log = require('./log');
 const log = require('../../lib/log');
 
 /**
@@ -663,8 +664,8 @@ async function main() {
     keyPath: '/root/fdm-arcane-specs/fdm-eu-2-1.key',
     certPath: '/root/fdm-arcane-specs/fdm-eu-2-1.pem',
     caPath: '/root/fdm-arcane-specs/ca.pem',
-    fluxApiBasePath: 'https://api.runonflux.io/',
-    sasApiBasePath: 'https://10.100.0.170/api/',
+    fluxApiBaseUrl: 'https://api.runonflux.io/',
+    sasApiBaseUrl: 'https://10.100.0.170/api/',
   });
 
   specFetcher.startAppSpecLoop();

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -1,0 +1,687 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const https = require('node:https');
+const { EventEmitter } = require('node:events');
+const url = require('node:url');
+
+const axios = require('axios');
+
+const log = require('../../lib/log');
+
+/**
+ * @typedef {{}} AppSpec
+ */
+
+/**
+ * @typedef {Array<AppSpec>} AppSpecList
+ */
+
+/**
+ * @typedef {{
+ *   etag: string,
+ *   maxAge: number,
+ *   specs: AppSpecList | null
+ * }} ParsedResponse
+ */
+
+class FdmDataFetcher extends EventEmitter {
+  // As of 17/07/25 the full spec list is 668191 bytes (0.67Mb)
+
+  /**
+   * @type {axios.AxiosInstance}
+   */
+  #fluxApi;
+
+  /**
+   * @type {axios.AxiosInstance}
+   */
+  #sasApi;
+
+  #aborted = false;
+
+  endpoints = {
+    globalAppSpecs: {
+      name: 'globalAppSpecs',
+      url: 'apps/globalappsspecifications',
+      sha: '',
+      etag: '',
+      maxAgeMs: 0,
+      defaultFetchMs: 30_000,
+      /**
+       * @type {NodeJS.Timeout | null}
+       */
+      timeout: null,
+    },
+    permMessages: {
+      name: 'permMessages',
+      url: 'apps/permanentmessages',
+      options: {
+        decompress: true,
+        headers: { 'Accept-Encoding': 'gzip, deflate, br, zstd' },
+      },
+      sha: '',
+      etag: '',
+      maxAgeMs: 0,
+      defaultFetchMs: 120_000,
+      /**
+       * @type {NodeJS.Timeout | null}
+       */
+      timeout: null,
+    },
+    sasDecrypt: {
+      url: 'decryptMessageRSA',
+    },
+  };
+
+  /**
+   *
+   * @param {{
+   *   keyPath: string,
+   *   certPath: string,
+   *   caPath: string,
+   *   fluxApiBaseUrl: string,
+   *   sasApiBaseUrl: string}} options
+   */
+  constructor(options) {
+    super();
+
+    const {
+      keyPath, certPath, caPath, fluxApiBaseUrl, sasApiBaseUrl,
+    } = options;
+
+    this.#fluxApi = axios.create({
+      baseURL: fluxApiBaseUrl,
+      timeout: 30_000,
+    });
+
+    this.#sasApi = axios.create({
+      baseURL: sasApiBaseUrl,
+      timeout: 10_000,
+      httpsAgent: new https.Agent({
+        key: fs.readFileSync(keyPath),
+        cert: fs.readFileSync(certPath),
+        ca: fs.readFileSync(caPath),
+      }),
+    });
+  }
+
+  static parseJson(data) {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * This is ugly. We only have to do this because the frontend passes arrays as strings
+   *
+   * @param {Object} blob
+   */
+  static hydrate(blob) {
+    const parsed = {};
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [key, value] of Object.entries(blob)) {
+      if (value instanceof Array) {
+        parsed[key] = value.map((item) => this.hydrate(item));
+      } else if (value.startsWith('[') && value.endsWith(']')) {
+        parsed[key] = this.parseJson(value);
+      } else {
+        parsed[key] = value;
+      }
+    }
+
+    return parsed;
+  }
+
+  /**
+   * If the passed in specification uses the g: parameter
+   * @param {Object} spec
+   * @returns {boolean}
+   */
+  static #isGApp(spec) {
+    const matcher = spec.version <= 3
+      ? () => spec.containerData.includes('g:')
+      : () => spec.compose.some((comp) => comp.containerData.includes('g:'));
+
+    const match = matcher();
+
+    return match;
+  }
+
+  /**
+   * We shouldn't be allowing these things in domains on the actual
+   * app spec. Removing them here makes no sense at all. The old
+   * version of this was broken also
+   *
+   * @param {Object} spec
+   */
+  static #buildFqdnMap(spec) {
+    const components = spec.version <= 3
+      ? [{ ports: spec.ports, domains: spec.domains }]
+      : spec.compose;
+
+    const fqdns = [];
+
+    components.forEach((comp) => {
+      for (let i = 0; i < comp.ports.length; i += 1) {
+        const portDomains = comp.domains[i].split(',');
+        portDomains.forEach((portDomain) => {
+          fqdns.push(portDomain
+            .replace('https://', '')
+            .replace('http://', '')
+            .replace(/[&/\\#,+()$~%'":*?<>{}]/g, '')
+            .toLowerCase());
+        });
+      }
+    });
+
+    const domainMap = { name: spec.name, fqdns };
+
+    return domainMap;
+  }
+
+  /**
+   * Decrypts content with aes key
+   * @param {string} appName application name.
+   * @param {Buffer} nonceCiphertextTag base64 encoded encrypted data
+   * @param {string} base64AesKey base64 encoded AesKey
+   * @returns {any} decrypted data
+   */
+  static decryptAesData(appName, nonceCiphertextTag, base64AesKey) {
+    try {
+      const key = Buffer.from(base64AesKey, 'base64');
+
+      const nonce = nonceCiphertextTag.subarray(0, 12);
+      const ciphertext = nonceCiphertextTag.subarray(12, -16);
+      const tag = nonceCiphertextTag.subarray(-16);
+
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, nonce);
+      decipher.setAuthTag(tag);
+
+      const decrypted = decipher.update(ciphertext, '', 'utf8') + decipher.final('utf8');
+
+      return decrypted;
+    } catch (error) {
+      log.error(`Error decrypting ${appName}`);
+      return null;
+    }
+  }
+
+  /**
+   *
+   * @param {axios.AxiosResponse} response
+   * @param {{head?: boolean}} options head - If the request is a head request
+   * @returns {ParsedResponse | null}
+   */
+  static #parseAxiosResponse(response, options = {}) {
+    const head = options.head ?? false;
+
+    if (!response) return null;
+
+    const { status, headers, data } = response;
+
+    if (status !== 200) {
+      log.info(`2XX status code recieved: ${status}, but not 200, skipping`);
+      return null;
+    }
+
+    const { etag, 'cache-control': cacheControl, fluxnode: backend } = headers;
+    const parsedUrl = url.parse(response.config.url);
+    console.log(parsedUrl.path, 'IS HEAD', head, 'cache-control', cacheControl);
+    const { maxAge } = /^max-age=(?<maxAge>\d+)$/.exec(cacheControl).groups;
+
+    // this is assuming that max-age is always present
+
+    const parsed = {
+      etag,
+      maxAgeMs: Number(maxAge) * 1_000,
+      backend,
+      payload: null,
+    };
+
+    if (head) return parsed;
+
+    if (!data) return parsed;
+
+    const { status: payloadStatus, data: payloadData } = data;
+
+    if (payloadStatus !== 'success') {
+      log.info(
+        'HTTP response was fine, but payload status was not '
+          + `success: ${payloadStatus}. Skipping`,
+      );
+
+      return parsed;
+    }
+
+    if (payloadData) parsed.payload = payloadData;
+
+    return parsed;
+  }
+
+  static get now() {
+    return process.hrtime.bigint();
+  }
+
+  async #decryptAppSpec(appSpec) {
+    // handle no enterprise?
+    const spec = appSpec;
+    const { enterprise } = appSpec;
+    const { sasDecrypt } = this.endpoints;
+
+    // we need to stop doing this
+    const endpoint = `apps/apporiginalowner/${spec.name}`;
+    const fluxRes = await this.#fluxApi.get(endpoint);
+
+    const parsedFluxRes = FdmDataFetcher.#parseAxiosResponse(fluxRes);
+
+    const { payload: originalOwner = null } = parsedFluxRes;
+
+    if (!originalOwner) return null;
+
+    const enterpriseBuf = Buffer.from(enterprise, 'base64');
+    const aesKeyEncrypted = enterpriseBuf.subarray(0, 256);
+    const nonceCiphertextTag = enterpriseBuf.subarray(256);
+
+    const base64EncryptedAesKey = aesKeyEncrypted.toString('base64');
+
+    const payload = {
+      fluxID: originalOwner,
+      appName: spec.name,
+      message: base64EncryptedAesKey,
+      blockHeight: 9999999,
+    };
+
+    const response = await this.#sasApi.post(sasDecrypt.url, payload);
+
+    const { status: responseStatus, data: responseData } = response;
+
+    if (responseStatus !== 200) return null;
+
+    const { status: payloadStatus, message: base64AesKey } = responseData;
+
+    if (payloadStatus !== 'ok') return null;
+
+    const decrypted = FdmDataFetcher.decryptAesData(
+      spec.name,
+      nonceCiphertextTag,
+      base64AesKey,
+    );
+
+    if (!decrypted) return null;
+
+    const parsed = FdmDataFetcher.parseJson(decrypted);
+
+    if (!parsed) return null;
+
+    const hydrated = FdmDataFetcher.hydrate(parsed);
+
+    spec.compose = hydrated.compose;
+    spec.contacts = hydrated.contacts;
+    // I don't like doing this. As we can no longer tell if it's enterprise
+    // or not. However, it's saving memory, and makes the add to map easier.
+    // There should really be another boolean field
+    spec.enterprise = '';
+
+    return spec;
+  }
+
+  async loop(runner, dataStore) {
+    const store = dataStore;
+
+    const ms = await runner();
+
+    if (this.#aborted) return;
+
+    store.timeout = setTimeout(() => this.loop(runner, store), ms);
+  }
+
+  startAppSpecLoop() {
+    const { globalAppSpecs } = this.endpoints;
+
+    const runner = this.appSpecRunner.bind(this);
+
+    setImmediate(() => this.loop(runner, globalAppSpecs));
+  }
+
+  startPermMessagesLoop() {
+    const { permMessages } = this.endpoints;
+
+    const runner = this.permMessageRunner.bind(this);
+
+    setImmediate(() => this.loop(runner, permMessages));
+  }
+
+  stopAppSpecLoop() {
+    // do other stuff here
+    const { globalAppSpecs } = this.endpoints;
+
+    clearTimeout(globalAppSpecs.timeout);
+    globalAppSpecs.timeout = null;
+  }
+
+  stopPermMessagesLoop() {
+    // do other stuff here
+    const { permMessages } = this.endpoints;
+
+    clearTimeout(permMessages.timeout);
+    permMessages.timeout = null;
+  }
+
+  static async getHttpCacheValues(store, fetcher) {
+    const headRes = await fetcher();
+
+    if (!headRes) return store.defaultFetchMs;
+
+    const {
+      etag = null,
+      maxAgeMs = store.defaultFetchMs,
+      backend = null,
+    } = headRes;
+
+    const logger = {
+      name: store.name,
+      verb: 'head',
+      backend,
+      etag,
+      sameEtag: etag === store.etag,
+      maxAgeMs,
+    };
+
+    console.log(logger);
+
+    if (maxAgeMs === 0) {
+      // the origin server is saying the cached could be stale, so we try
+      // again in 5 seconds
+      return 5_000;
+    }
+
+    if (etag && etag === store.etag) {
+      return maxAgeMs;
+    }
+
+    return 0;
+  }
+
+  async processPermMessages(messages) {
+    // do processing here instead of filtering elsewhere
+    this.emit('permMessagesUpdated', messages);
+  }
+
+  async processAppSpecs(specs) {
+    // fix these riduculous names
+    const gAppsMap = new Map();
+    const nonGAppsMap = new Map();
+    const appFqdns = [];
+    const enterpriseApps = [];
+
+    const specMapper = (_specs) => {
+      _specs.forEach((spec) => {
+        const { version, enterprise } = spec;
+
+        const isEnterprise = Boolean(version >= 8 && enterprise);
+
+        if (isEnterprise) {
+          enterpriseApps.push(spec);
+          return;
+        }
+
+        const isGApp = FdmDataFetcher.#isGApp(spec);
+        const appMap = isGApp ? gAppsMap : nonGAppsMap;
+
+        appMap.set(spec.name, spec);
+
+        const fqdns = FdmDataFetcher.#buildFqdnMap(spec);
+        appFqdns.push(fqdns);
+      });
+    };
+
+    specMapper(specs);
+
+    const logger = () => ({
+      GApps: gAppsMap.size,
+      NonGApps: nonGAppsMap.size,
+      Enterprise: enterpriseApps.length,
+      Total: gAppsMap.size + nonGAppsMap.size,
+    });
+
+    console.log('Before decryption:\n', logger());
+
+    const decryptPromises = enterpriseApps.map((spec) => this.#decryptAppSpec(spec));
+
+    const decryptedSpecs = await Promise.all(decryptPromises);
+
+    specMapper(decryptedSpecs);
+    // console.log(util.inspect(decryptedSpecs, { colors: true, depth: null }));
+
+    console.log('After decryption:\n', logger());
+
+    this.emit('appSpecsUpdated', { gApps: gAppsMap, nonGApps: nonGAppsMap, appFqdns });
+  }
+
+  async getAndProcessPermMessages() {
+    const { permMessages } = this.endpoints;
+
+    const getRes = await this.doPermMessagesHttpGet();
+    if (!getRes) return permMessages.defaultFetchMs;
+
+    const {
+      payload, etag, maxAgeMs, backend,
+    } = getRes;
+
+    permMessages.etag = etag;
+    permMessages.maxAgeMs = maxAgeMs;
+
+    const fetchTime = FdmDataFetcher.now;
+
+    // we could get the response as text and hash that, but it changes
+    // the logic quite a bit. So a better compromise is to stringify again
+    // until the load balancers are fixed (return same api endpoint, i.e. same etag)
+    const hasher = crypto.createHash('sha1');
+    const specSha = hasher.update(JSON.stringify(payload)).digest('hex');
+
+    if (specSha !== permMessages.sha) {
+      console.log('permMessages have a different SHA... processing');
+      permMessages.sha = specSha;
+      await this.processPermMessages(payload);
+    }
+
+    const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
+    const sleepTimeMs = Math.max(0, maxAgeMs - elapsedMs);
+
+    const logger = {
+      name: 'permMessages',
+      verb: 'get',
+      backend,
+      etag,
+      specSize: payload ? payload.length : 0,
+      sleepTimeMs,
+    };
+    console.log(logger);
+
+    return sleepTimeMs;
+  }
+
+  async getAndProcessAppSpecs() {
+    const { globalAppSpecs } = this.endpoints;
+
+    const getRes = await this.doAppSpecsHttpGet();
+    if (!getRes) return globalAppSpecs.defaultFetchMs;
+
+    const {
+      payload, etag, maxAgeMs, backend,
+    } = getRes;
+
+    globalAppSpecs.etag = etag;
+    globalAppSpecs.maxAgeMs = maxAgeMs;
+
+    const fetchTime = FdmDataFetcher.now;
+
+    // we could get the response as text and hash that, but it changes
+    // the logic quite a bit. So a better compromise is to stringify again
+    // until the load balancers are fixed (return same api endpoint, i.e. same etag)
+    const hasher = crypto.createHash('sha1');
+    const specSha = hasher.update(JSON.stringify(payload)).digest('hex');
+
+    if (specSha !== globalAppSpecs.sha) {
+      console.log('globalAppSpecs have a different SHA... processing');
+      globalAppSpecs.sha = specSha;
+      await this.processAppSpecs(payload);
+    }
+
+    const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
+    const sleepTimeMs = Math.max(0, maxAgeMs - elapsedMs);
+
+    const logger = {
+      name: 'globalAppSpecs',
+      verb: 'get',
+      backend,
+      etag,
+      specSize: payload ? payload.length : 0,
+      sleepTimeMs,
+    };
+    console.log(logger);
+
+    return sleepTimeMs;
+  }
+
+  /**
+   *
+   * @returns {Promise<>}
+   */
+  async doPermMessagesHttpHead() {
+    const response = await this.#fluxApi
+      .head(this.endpoints.permMessages.url)
+      .catch((err) => {
+        log.info(`Unable to do HTTP HEAD for app specs: ${err.message}`);
+        return null;
+      });
+
+    const parsed = FdmDataFetcher.#parseAxiosResponse(response, {
+      head: true,
+    });
+
+    return parsed;
+  }
+
+  /**
+   *
+   * @returns {Promise<>}
+   */
+  async doAppSpecsHttpHead() {
+    const response = await this.#fluxApi
+      .head(this.endpoints.globalAppSpecs.url)
+      .catch((err) => {
+        log.info(`Unable to do HTTP HEAD for app specs: ${err.message}`);
+        return null;
+      });
+
+    const parsed = FdmDataFetcher.#parseAxiosResponse(response, {
+      head: true,
+    });
+
+    return parsed;
+  }
+
+  async doAppSpecsHttpGet() {
+    const response = await this.#fluxApi
+      .get(this.endpoints.globalAppSpecs.url)
+      .catch((err) => {
+        log.info(`Unable to do HTTP GET for app specs: ${err.message}`);
+        return null;
+      });
+
+    const parsed = FdmDataFetcher.#parseAxiosResponse(response);
+
+    return parsed;
+  }
+
+  async doPermMessagesHttpGet() {
+    // we get the compressed output. 56Mb vs 11Mb
+    // this is still ridiculous though - we don't need to fetch the entire
+    // message list every time
+    const { permMessages: options } = this.endpoints;
+
+    const response = await this.#fluxApi
+      .get(this.endpoints.permMessages.url, options)
+      .catch((err) => {
+        log.info(`Unable to do HTTP GET for app specs: ${err.message}`);
+        return null;
+      });
+
+    const parsed = FdmDataFetcher.#parseAxiosResponse(response);
+
+    return parsed;
+  }
+
+  /**
+   * Checks the latest specs via ETAG, if different, runs a GET.
+   * @returns {Promise<number>} Ms until next loop time
+   */
+  async appSpecRunner() {
+    const { globalAppSpecs } = this.endpoints;
+
+    if (globalAppSpecs.etag) {
+      const store = globalAppSpecs;
+      const fetcher = this.doAppSpecsHttpHead.bind(this);
+
+      const cacheMaxAgeMs = await FdmDataFetcher.getHttpCacheValues(store, fetcher);
+
+      if (cacheMaxAgeMs) return cacheMaxAgeMs;
+    }
+
+    const getMaxAgeMs = await this.getAndProcessAppSpecs();
+
+    return getMaxAgeMs;
+  }
+
+  /**
+   * Checks the latest permanent messages via ETAG, if different, runs a GET.
+   * @returns {Promise<number>} Ms until next loop time
+   */
+  async permMessageRunner() {
+    const { permMessages } = this.endpoints;
+
+    if (permMessages.etag) {
+      const store = permMessages;
+      const fetcher = this.doPermMessagesHttpHead.bind(this);
+      const cacheMaxAgeMs = await FdmDataFetcher.getHttpCacheValues(store, fetcher);
+
+      if (cacheMaxAgeMs) return cacheMaxAgeMs;
+    }
+
+    const getMaxAgeMs = await this.getAndProcessPermMessages();
+
+    return getMaxAgeMs;
+  }
+}
+
+async function main() {
+  const specFetcher = new FdmDataFetcher({
+    keyPath: '/root/fdm-arcane-specs/fdm-eu-2-1.key',
+    certPath: '/root/fdm-arcane-specs/fdm-eu-2-1.pem',
+    caPath: '/root/fdm-arcane-specs/ca.pem',
+    fluxApiBasePath: 'https://api.runonflux.io/',
+    sasApiBasePath: 'https://10.100.0.170/api/',
+  });
+
+  specFetcher.startAppSpecLoop();
+  specFetcher.startPermMessagesLoop();
+  specFetcher.on('appSpecsUpdated', (specs) => console.log(
+    'Received appSpecsUpdated event with spec sizes:',
+    specs.gApps.size,
+    specs.nonGApps.size,
+  ));
+  specFetcher.on('permMessagesUpdated', (messages) => console.log(
+    'Received permMessagesUpdated event with spec size:',
+    messages.length,
+  ));
+}
+
+module.exports = { FdmDataFetcher };
+
+if (require.main === module) {
+  main();
+}

--- a/src/services/flux/index.js
+++ b/src/services/flux/index.js
@@ -75,7 +75,10 @@ async function getFluxIPs(tier) {
 // Retrieves application specifications from network api
 async function getAppSpecifications() {
   try {
-    const fluxnodeList = await axios.get('https://api.runonflux.io/apps/globalappsspecifications', axiosConfig);
+    const fluxnodeList = await axios.get(
+      'https://api.runonflux.io/apps/globalappsspecifications',
+      axiosConfig
+    );
     if (fluxnodeList.data.status === 'success') {
       return fluxnodeList.data.data || [];
     }
@@ -88,11 +91,16 @@ async function getAppSpecifications() {
 // Retrieves IP's that a given application in running on
 async function getApplicationLocation(appName) {
   try {
-    const fluxnodeList = await axios.get(`https://api.runonflux.io/apps/location/${appName}`, axiosConfig);
+    const fluxnodeList = await axios.get(
+      `https://api.runonflux.io/apps/location/${appName}`,
+      axiosConfig
+    );
     if (fluxnodeList.data.status === 'success') {
       return fluxnodeList.data.data || [];
     }
-    console.log(`${fluxnodeList.data.status} received from getApplicationLocation`);
+    console.log(
+      `${fluxnodeList.data.status} received from getApplicationLocation`
+    );
     return [];
   } catch (e) {
     log.error(e);

--- a/src/services/flux/index.js
+++ b/src/services/flux/index.js
@@ -103,7 +103,7 @@ async function getApplicationLocation(appName) {
     );
     return [];
   } catch (e) {
-    log.error(e);
+    log.error(`Failed to get app location for ${appName}. ${e.message}`);
     return [];
   }
 }

--- a/src/services/flux/index.js
+++ b/src/services/flux/index.js
@@ -77,7 +77,7 @@ async function getAppSpecifications() {
   try {
     const fluxnodeList = await axios.get(
       'https://api.runonflux.io/apps/globalappsspecifications',
-      axiosConfig
+      axiosConfig,
     );
     if (fluxnodeList.data.status === 'success') {
       return fluxnodeList.data.data || [];
@@ -93,13 +93,13 @@ async function getApplicationLocation(appName) {
   try {
     const fluxnodeList = await axios.get(
       `https://api.runonflux.io/apps/location/${appName}`,
-      axiosConfig
+      axiosConfig,
     );
     if (fluxnodeList.data.status === 'success') {
       return fluxnodeList.data.data || [];
     }
     console.log(
-      `${fluxnodeList.data.status} received from getApplicationLocation`
+      `${fluxnodeList.data.status} received from getApplicationLocation`,
     );
     return [];
   } catch (e) {

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -391,18 +391,18 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary) {
 
   // Enhanced ACLs with WebSocket detection and specific endpoint detection
   const specificEndpointsAcl = `  acl is_sticky_endpoint path_beg /id/loginphrase
-  acl is_sticky_endpoint path_beg /id/emergencyphrase 
-  acl is_sticky_endpoint path_beg /id/providesign 
+  acl is_sticky_endpoint path_beg /id/emergencyphrase
+  acl is_sticky_endpoint path_beg /id/providesign
   acl is_sticky_endpoint path_beg /id/verifylogin\n`;
 
   // ACLs for endpoints that should use roundrobin
-  const roundrobinEndpointsAcl = `  acl is_roundrobin_endpoint path_beg apps/calculatefiatandfluxprice 
-  acl is_roundrobin_endpoint path_beg /apps/verifyappregistrationspecifications 
-  acl is_roundrobin_endpoint path_beg /apps/verifyappupdatespecifications 
-  acl is_roundrobin_endpoint path_beg /apps/appregister 
-  acl is_roundrobin_endpoint path_beg /apps/appupdate 
-  acl is_roundrobin_endpoint path_beg /apps/temporarymessages 
-  acl is_roundrobin_endpoint path_beg /apps/location 
+  const roundrobinEndpointsAcl = `  acl is_roundrobin_endpoint path_beg apps/calculatefiatandfluxprice
+  acl is_roundrobin_endpoint path_beg /apps/verifyappregistrationspecifications
+  acl is_roundrobin_endpoint path_beg /apps/verifyappupdatespecifications
+  acl is_roundrobin_endpoint path_beg /apps/appregister
+  acl is_roundrobin_endpoint path_beg /apps/appupdate
+  acl is_roundrobin_endpoint path_beg /apps/temporarymessages
+  acl is_roundrobin_endpoint path_beg /apps/location
   acl is_roundrobin_endpoint path_beg /apps/testappinstall\n`;
 
   const webSocketAcl = `  acl is_websocket hdr(connection) -i upgrade

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -287,10 +287,8 @@ backend ${domainUsed}backend
 }
 
 function generateMinecraftACLs(app) {
-  console.log(app.domain);
   const aclName = app.domain.split('.').join('');
   const appName = app.domain.split('.')[0];
-  console.log(appName);
 
   const nameLength = appName.length + 1;
   const domainLength = app.domain.length;

--- a/test.js
+++ b/test.js
@@ -24,8 +24,8 @@ async function selectIPforG(ips, app) {
 }
 
 async function test() {
-const b = await selectIPforG(['123.234','2345.342','456.34234','342.434'], 'test');
-console.log(b);
+  const b = await selectIPforG(['123.234', '2345.342', '456.34234', '342.434'], 'test');
+  console.log(b);
 }
 
 test();
@@ -57,13 +57,13 @@ let configuredApps = [{
 const updatingConfig = JSON.parse(JSON.stringify(recentlyConfiguredApps));
 // merge recentlyConfiguredApps with currently configuredApps
 for (const app of configuredApps) {
-  let appExists = updatingConfig.find((a) => a.appName === app.appName);
+  const appExists = updatingConfig.find((a) => a.appName === app.appName);
   if (!appExists) {
     updatingConfig.push(app);
   } else {
     updatingConfig.splice(updatingConfig.indexOf(appExists), 1, app);
     // console.log(app);
-   // appExists = app; // this is also updating element in updatingConfig
+    // appExists = app; // this is also updating element in updatingConfig
   }
 }
 console.log(updatingConfig);


### PR DESCRIPTION
**ALL FDMs now have access to the spec decryption api**

Adds spec decryption functionality for FDM to be able to get ports etc for balancing.

This PR has what I would consider the bare minimum changes to make this happen.

I would like to rebuild our FDM setup soon from the ground up using modern HA proxy api's. We can make this a lot more efficient, and easier to reason what is happening. (without having to reload all the time and supporting many more features for customers)

Will also split out the functionality - FDM / CDM tries to do too much all mashed into the same modules.

Here is the main logic changes:

### Data fetching

Previously, FDM would run in a loop and fetch the specs / permanent messages every 5 minutes, regardless if there were new specs or not. This is quite inefficient, i.e. there might have been spec changes a lot sooner, or none at all - and we have pulled all the data for nothing.

We now do HTTP HEAD requests and use the `Cache-Control: max-age=x` and `etag: W/"35b69bf-hGUy5YGGX2UVTma3NAm2tR8JC3Q"` headers. This allows us to know when the api will refresh the data (max-age) and we use the etag to essentially get the hash of the data - so we know if it has changed or not.

Using head requests lets you look at the headers without having to download the entire payload (Over 11Mb compressed for the permanentMessages, and about 0.7Mb for the specs)

If the data hasn't changed - we don't pull it.

However, one thing I've noticed, I think this might be due to some HA Proxy changes recently, is that you quite often get a different backend server. We need to fix this, as using an api - you should get the same backend. If not, it breaks caching. I.e. you get a different server with a different etag and max-age.

To work around this - I also hash the recieved data, but it's less than ideal as most of the nodes have a different view of the network global apps specs (we need to look at this too as they shouldn't).

The actual data fetching for `apps/permanentmessages` and `apps/globalappsspecifications` is now in a different class - `FdmDataFetcher` - this manages all the caching on the api and emits events when it detects a change in the specs - these events trigger the Gapps and NonGapps processing.

This is a lot better as we are only pulling the data once for both gapps and nongapps and the dataFetcher sorts them with a single iteration over the specs.

If an update is already running - a config update gets queued (only one can be queued)

### Logs

Tidy up the console logs. We were logging entire HA proxy configs and all sorts of other junk - so the logs were basically meaningless.

### Spec caching

We cache the decrypted specs for 24 hours, based on hash. This saves having to decrypt the specs on every update - as they are unlikely to change.

Here is an app deing decrypted (You have to browse direct to the FDM as the Main Proxies redirect to USA (which obviously isn't updated):

<img width="1632" height="894" alt="Screenshot 2025-07-21 at 4 28 28 PM" src="https://github.com/user-attachments/assets/2cdeedb2-43c4-4160-b442-ea584ae02f0f" />

### Spec decryption Api

The spec api is now behind `keepalived` which the FDMs use the virtual IP presented by keepalived to connect to the api. It also load balances across 2 backend nodes (nginx reverse proxies) If nginx goes down - every second request will fail for 30 seconds (it's round robin) until keepalived removes one of the backends. If a request does fail, it is retried by the fdm code 4 times over 1 minute - so should always get a response. I can make this a lot faster - but don't think it's necessary.

If one of the load balancers goes down, the other one takes over within one second. (It sends a gratituous arp and takes over the VIP)

The load balancers (keepalived) are on the same VM as the backends (nginx)

