### PR TITLE
Bugfix: Main Home / API FDM crashes

### DIFF
--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -999,6 +999,17 @@ async function obtainCertificatesMode() {
  * @returns {Promise<void>}
  */
 async function startApplicationProcessing() {
+  if (!dataFetcher) {
+    // these are symlinked to the correct key / pem on every box
+    dataFetcher = new FdmDataFetcher({
+      keyPath: '/etc/ssl/private/fdm-arcane.key',
+      certPath: '/etc/ssl/certs/fdm-arcane.pem',
+      caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
+      fluxApiBaseUrl: 'https://api.runonflux.io/',
+      sasApiBaseUrl: 'https://10.100.0.170/api/',
+    });
+  }
+
   const gAppLoop = async () => {
     await generateAndReplaceMainApplicationHaproxyGAppsConfig();
     setImmediate(gAppLoop);
@@ -1097,17 +1108,6 @@ function initializeServices() {
 }
 
 async function start() {
-  if (!dataFetcher) {
-    // these are symlinked to the correct key / pem on every box
-    dataFetcher = new FdmDataFetcher({
-      keyPath: '/etc/ssl/private/fdm-arcane.key',
-      certPath: '/etc/ssl/certs/fdm-arcane.pem',
-      caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
-      fluxApiBaseUrl: 'https://api.runonflux.io/',
-      sasApiBaseUrl: 'https://10.100.0.170/api/',
-    });
-  }
-
   try {
     log.info('Initiating FDM API services...');
     initializeServices();


### PR DESCRIPTION
Main FDMs don't have Arcane keys. (They don't need them)

This PR just moves the dataFetcher instantiation to where it is needed.