### PR TITLE
Bugfix: dataFetcher check

### DIFF
--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1082,7 +1082,7 @@ function initializeServices() {
     } else if (
       config.mainDomain === config.cloudflare.domain
       && config.cloudflare.manageapp
-      && !dataFetcher.listenerCount('appSpecsUpdated')
+      && !dataFetcher
     ) {
       // only runs on main FDM handles X.APP.runonflux.io. This only runs once
       // to add event listeners
@@ -1092,6 +1092,7 @@ function initializeServices() {
     } else if (
       config.mainDomain === config.pDNS.domain
       && config.pDNS.manageapp
+      && !dataFetcher
     ) {
       // only runs on main FDM handles X.APP.runonflux.io. This only runs once
       startApplicationProcessing();


### PR DESCRIPTION
Fixes issue where we were checking if datafetcher had listeners applied. Now we just check if it exists.

This was stopping fdm from starting