### PR TITLE
Feature: aggregate locations

### DIFF
--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -839,7 +839,7 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
     }
 
     const elapsedAppsS = Math.round((appsProcessingTimeNs / 1_000_000_000) * 100) / 100;
-    console.log(`Total apps processing time: ${elapsedAppsS}`);
+    console.log(`Total apps processing time. Elapsed: ${elapsedAppsS}`);
 
     if (configuredApps.length < 10) {
       throw new Error('PANIC PLEASE DEV HELP ME');

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -621,6 +621,8 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
     // continue with appsOK
     const configuredApps = []; // object of domain, port, ips for backend and isRdata
     for (const app of appsOK) {
+      const startTime = process.hrtime.bigint();
+
       log.info(`Configuring ${app.name}`);
 
       const appLocations = appsLocations.get(app.name) || [];
@@ -828,6 +830,10 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
           throw new Error(`Application ${app.name} is not running well PANIC.`);
         }
       }
+
+      const elapsedNs = Number(process.hrtime.bigint() - startTime);
+      const elapsedS = Math.round((elapsedNs / 1_000_000_000) * 100) / 100;
+      log.info(`App: ${app.name}, Elapsed: ${elapsedS}`);
     }
 
     if (configuredApps.length < 10) {

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1065,13 +1065,18 @@ async function startApplicationProcessing() {
 
     configRunning = true;
 
-    // run the gapps first
-    await generateAndReplaceMainApplicationHaproxyGAppsConfig();
-    await generateAndReplaceMainApplicationHaproxyConfig();
+    const appProcessor = async () => {
+      const tasks = [
+        generateAndReplaceMainApplicationHaproxyGAppsConfig(),
+        generateAndReplaceMainApplicationHaproxyConfig(),
+      ];
+      await Promise.all(tasks);
+    };
+
+    await appProcessor();
 
     if (configQueued) {
-      await generateAndReplaceMainApplicationHaproxyGAppsConfig();
-      await generateAndReplaceMainApplicationHaproxyConfig();
+      await appProcessor();
       configQueued = false;
     }
 

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -581,6 +581,8 @@ function addConfigurations(configuredApps, app, appIps, gMode) {
  * @param {Map<string, Object>} globalAppSpecs Pre filtered NonG Applications
  */
 async function generateAndReplaceMainApplicationHaproxyConfig() {
+  const startTime = process.hrtime.bigint();
+
   try {
     log.info('Non G Mode STARTED');
 
@@ -865,11 +867,15 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
   } catch (error) {
     log.error(error);
   } finally {
-    log.info('Non G Mode ENDED');
+    const elapsedNs = Number(process.hrtime.bigint() - startTime);
+    const elapsedS = Math.round((elapsedNs / 1_000_000_000) * 100) / 100;
+    log.info(`Non G Mode ENDED. Elapsed: ${elapsedS}`);
   }
 }
 
 async function generateAndReplaceMainApplicationHaproxyGAppsConfig() {
+  const startTime = process.hrtime.bigint();
+
   try {
     log.info('G Mode STARTED');
 
@@ -972,7 +978,9 @@ async function generateAndReplaceMainApplicationHaproxyGAppsConfig() {
   } catch (error) {
     log.error(error);
   } finally {
-    log.info('G Mode ENDED');
+    const elapsedNs = Number(process.hrtime.bigint() - startTime);
+    const elapsedS = Math.round((elapsedNs / 1_000_000_000) * 100) / 100;
+    log.info(`G Mode ENDED. Elapsed: ${elapsedS}`);
   }
 }
 

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -705,6 +705,9 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
             });
             appIpsOnAppsChecks = [];
           }
+          // as the application checks uses network, the responses can come in
+          // a different order, so we sort the responses by ip address.
+          serviceHelper.sortIPAddresses(appIps);
         } else if (
           app.compose
           && app.compose.find((comp) => comp.repotag.toLowerCase().includes('runonflux/shared-db'))

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -869,7 +869,7 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
   } finally {
     const elapsedNs = Number(process.hrtime.bigint() - startTime);
     const elapsedS = Math.round((elapsedNs / 1_000_000_000) * 100) / 100;
-    log.info(`Non G Mode ENDED. Elapsed: ${elapsedS}`);
+    log.info(`Non G Mode ENDED. Elapsed: ${elapsedS}s`);
   }
 }
 
@@ -980,7 +980,7 @@ async function generateAndReplaceMainApplicationHaproxyGAppsConfig() {
   } finally {
     const elapsedNs = Number(process.hrtime.bigint() - startTime);
     const elapsedS = Math.round((elapsedNs / 1_000_000_000) * 100) / 100;
-    log.info(`G Mode ENDED. Elapsed: ${elapsedS}`);
+    log.info(`G Mode ENDED. Elapsed: ${elapsedS}s`);
   }
 }
 

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1049,6 +1049,12 @@ async function startApplicationProcessing() {
     await generateAndReplaceMainApplicationHaproxyGAppsConfig();
     await generateAndReplaceMainApplicationHaproxyConfig();
 
+    if (configQueued) {
+      await generateAndReplaceMainApplicationHaproxyGAppsConfig();
+      await generateAndReplaceMainApplicationHaproxyConfig();
+      configQueued = false;
+    }
+
     configRunning = false;
   };
 

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1000,16 +1000,16 @@ async function obtainCertificatesMode() {
  * @returns {Promise<void>}
  */
 async function startApplicationProcessing() {
-  if (!dataFetcher) {
-    // these are symlinked to the correct key / pem on every box
-    dataFetcher = new FdmDataFetcher({
-      keyPath: '/etc/ssl/private/fdm-arcane.key',
-      certPath: '/etc/ssl/certs/fdm-arcane.pem',
-      caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
-      fluxApiBaseUrl: 'https://api.runonflux.io/',
-      sasApiBaseUrl: 'https://10.100.0.170/api/',
-    });
-  }
+  if (dataFetcher) return;
+
+  // these are symlinked to the correct key / pem on every box
+  dataFetcher = new FdmDataFetcher({
+    keyPath: '/etc/ssl/private/fdm-arcane.key',
+    certPath: '/etc/ssl/certs/fdm-arcane.pem',
+    caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
+    fluxApiBaseUrl: 'https://api.runonflux.io/',
+    sasApiBaseUrl: 'https://10.100.0.170/api/',
+  });
 
   const gAppLoop = async () => {
     await generateAndReplaceMainApplicationHaproxyGAppsConfig();
@@ -1041,6 +1041,7 @@ async function startApplicationProcessing() {
   // We just run these once prior to the fetch loops ss the data is populated
   await dataFetcher.permMessageRunner();
   await dataFetcher.appSpecRunner();
+  await dataFetcher.appsLocationsRunner();
 
   // Run non g first as this takes significantly longer. 8 minutes vs about 30
   // seconds. The reason we run these once first, is so that we don't sit there
@@ -1053,6 +1054,7 @@ async function startApplicationProcessing() {
 
   dataFetcher.startAppSpecLoop();
   dataFetcher.startPermMessagesLoop();
+  dataFetcher.startAppsLocationsLoop();
 
   setImmediate(gAppLoop);
   setImmediate(nonGAppLoop);

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1044,7 +1044,7 @@ async function startApplicationProcessing() {
   // };
 
   const locationsHandler = async (appsLocs) => {
-    appsLocations = appsLocs;
+    if (appsLocs) appsLocations = appsLocs;
 
     if (configQueued && configRunning) {
       console.log('appsLocationsUpdated event received, while '

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -582,6 +582,7 @@ function addConfigurations(configuredApps, app, appIps, gMode) {
  */
 async function generateAndReplaceMainApplicationHaproxyConfig() {
   const startTime = process.hrtime.bigint();
+  let appsProcessingTimeNs = 0;
 
   try {
     log.info('Non G Mode STARTED');
@@ -621,7 +622,7 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
     // continue with appsOK
     const configuredApps = []; // object of domain, port, ips for backend and isRdata
     for (const app of appsOK) {
-      const startTime = process.hrtime.bigint();
+      const appStartTime = process.hrtime.bigint();
 
       log.info(`Configuring ${app.name}`);
 
@@ -831,10 +832,14 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
         }
       }
 
-      const elapsedNs = Number(process.hrtime.bigint() - startTime);
+      const elapsedNs = Number(process.hrtime.bigint() - appStartTime);
       const elapsedS = Math.round((elapsedNs / 1_000_000_000) * 100) / 100;
+      appsProcessingTimeNs += elapsedNs;
       log.info(`App: ${app.name}, Elapsed: ${elapsedS}`);
     }
+
+    const elapsedAppsS = Math.round((appsProcessingTimeNs / 1_000_000_000) * 100) / 100;
+    console.log(`Total apps processing time: ${elapsedAppsS}`);
 
     if (configuredApps.length < 10) {
       throw new Error('PANIC PLEASE DEV HELP ME');

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -620,6 +620,14 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
 
       const appLocations = appsLocations.get(app.name) || [];
 
+      let searchCount = 0;
+      while (!appLocations.length && searchCount < 5) {
+        searchCount += 1;
+        // eslint-disable-next-line no-await-in-loop
+        const newLocations = await fluxService.getApplicationLocation(app.name);
+        appLocations.push(...newLocations);
+      }
+
       if (app.name === 'blockbookbitcoin') {
         appLocations.push({ ip: '[2001:41d0:d00:b800::20]:9130' });
         appLocations.push({ ip: '[2001:41d0:d00:b800::21]:9130' });
@@ -887,6 +895,14 @@ async function generateAndReplaceMainApplicationHaproxyGAppsConfig() {
       log.info(`Configuring ${app.name}`);
 
       const appLocations = appsLocations.get(app.name) || [];
+
+      let searchCount = 0;
+      while (!appLocations.length && searchCount < 5) {
+        searchCount += 1;
+        // eslint-disable-next-line no-await-in-loop
+        const newLocations = await fluxService.getApplicationLocation(app.name);
+        appLocations.push(...newLocations);
+      }
 
       if (appLocations.length > 0) {
         const appIps = [];

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable no-restricted-syntax */
 const config = require('config');
-const crypto = require('node:crypto');
+// const crypto = require('node:crypto');
 const fs = require('fs').promises;
 const log = require('../lib/log');
 const ipService = require('./ipService');
@@ -864,12 +864,12 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
 
     log.info('Changes in Non G Mode configuration detected');
 
-    const appsHasher = crypto.createHash('sha1');
-    const appsSha = appsHasher.update(serializedApps).digest('hex');
-    const lastAppsHasher = crypto.createHash('sha1');
-    const lastAppsSha = lastAppsHasher.update(lastSerializedApps).digest('hex');
+    // const appsHasher = crypto.createHash('sha1');
+    // const appsSha = appsHasher.update(serializedApps).digest('hex');
+    // const lastAppsHasher = crypto.createHash('sha1');
+    // const lastAppsSha = lastAppsHasher.update(lastSerializedApps).digest('hex');
 
-    console.log('Non G apps SHA:', appsSha, 'Last Non G apps SHA:', lastAppsSha);
+    // console.log('Non G apps SHA:', appsSha, 'Last Non G apps SHA:', lastAppsSha);
 
     // we need to put always in same order to avoid. non g first g at end
     haproxyAppsConfig = configuredApps.concat(recentlyConfiguredGApps);
@@ -969,12 +969,12 @@ async function generateAndReplaceMainApplicationHaproxyGAppsConfig() {
 
     log.info('Changes in G Mode configuration detected');
 
-    const appsHasher = crypto.createHash('sha1');
-    const appsSha = appsHasher.update(serializedApps).digest('hex');
-    const lastAppsHasher = crypto.createHash('sha1');
-    const lastAppsSha = lastAppsHasher.update(lastSerializedApps).digest('hex');
+    // const appsHasher = crypto.createHash('sha1');
+    // const appsSha = appsHasher.update(serializedApps).digest('hex');
+    // const lastAppsHasher = crypto.createHash('sha1');
+    // const lastAppsSha = lastAppsHasher.update(lastSerializedApps).digest('hex');
 
-    console.log('G apps SHA:', appsSha, 'Last G apps SHA:', lastAppsSha);
+    // console.log('G apps SHA:', appsSha, 'Last G apps SHA:', lastAppsSha);
 
     let haproxyAppsConfig = [];
 

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -839,7 +839,7 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
     }
 
     const elapsedAppsS = Math.round((appsProcessingTimeNs / 1_000_000_000) * 100) / 100;
-    console.log(`Total apps processing time. Elapsed: ${elapsedAppsS}`);
+    log.info(`Total apps processing time. Elapsed: ${elapsedAppsS}`);
 
     if (configuredApps.length < 10) {
       throw new Error('PANIC PLEASE DEV HELP ME');
@@ -1090,8 +1090,12 @@ async function startApplicationProcessing() {
       state.running = false;
     };
 
-    setImmediate(() => handler('gApps', runQueue.gApps, generateAndReplaceMainApplicationHaproxyGAppsConfig));
-    setImmediate(() => handler('nonGApps', runQueue.nonGApps, generateAndReplaceMainApplicationHaproxyConfig));
+    const promises = [
+      handler('gApps', runQueue.gApps, generateAndReplaceMainApplicationHaproxyGAppsConfig),
+      handler('nonGApps', runQueue.nonGApps, generateAndReplaceMainApplicationHaproxyConfig),
+    ];
+
+    await Promise.all(promises);
   };
 
   dataFetcher.on(

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -622,6 +622,8 @@ async function generateAndReplaceMainApplicationHaproxyConfig() {
 
       let searchCount = 0;
       while (!appLocations.length && searchCount < 5) {
+        log.info(`Application: ${app.name} not found in global locations... `
+          + 'searching nodes');
         searchCount += 1;
         // eslint-disable-next-line no-await-in-loop
         const newLocations = await fluxService.getApplicationLocation(app.name);
@@ -898,6 +900,8 @@ async function generateAndReplaceMainApplicationHaproxyGAppsConfig() {
 
       let searchCount = 0;
       while (!appLocations.length && searchCount < 5) {
+        log.info(`Application: ${app.name} not found in global locations... `
+          + 'searching nodes');
         searchCount += 1;
         // eslint-disable-next-line no-await-in-loop
         const newLocations = await fluxService.getApplicationLocation(app.name);

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -698,6 +698,8 @@ class FdmDataFetcher extends EventEmitter {
   async getAndProcessAppsLocations() {
     const { appsLocations } = this.endpoints;
 
+    // this call is 2.1Mb without compression and 0.37Mb compressed (axios uses
+    // compression)
     const getRes = await this.doAppsLocationsHttpGet();
     if (!getRes) return appsLocations.defaultFetchMs;
 

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -895,7 +895,7 @@ class FdmDataFetcher extends EventEmitter {
 }
 
 async function main() {
-  const specFetcher = new FdmDataFetcher({
+  const dataFetcher = new FdmDataFetcher({
     keyPath: '/etc/ssl/private/fdm-arcane.key',
     certPath: '/etc/ssl/certs/fdm-arcane.pem',
     caPath: '/etc/ssl/certs/fdm-arcane-ca.pem',
@@ -903,16 +903,21 @@ async function main() {
     sasApiBaseUrl: 'https://10.100.0.170/api/',
   });
 
-  specFetcher.startAppSpecLoop();
-  specFetcher.startPermMessagesLoop();
-  specFetcher.on('appSpecsUpdated', (specs) => console.log(
+  dataFetcher.startAppSpecLoop();
+  dataFetcher.startPermMessagesLoop();
+  dataFetcher.startAppsLocationsLoop();
+  dataFetcher.on('appSpecsUpdated', (specs) => console.log(
     'Received appSpecsUpdated event with spec sizes:',
     specs.gApps.size,
     specs.nonGApps.size,
   ));
-  specFetcher.on('permMessagesUpdated', (messages) => console.log(
+  dataFetcher.on('permMessagesUpdated', (messages) => console.log(
     'Received permMessagesUpdated event with spec size:',
     messages.length,
+  ));
+  dataFetcher.on('appsLocationsUpdated', (locations) => console.log(
+    'Received appsLocationsUpdated event with location size:',
+    locations.size,
   ));
 }
 

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -813,6 +813,19 @@ class FdmDataFetcher extends EventEmitter {
     return parsed;
   }
 
+  async doAppsLocationsHttpGet() {
+    const response = await this.#fluxApi
+      .get(this.endpoints.appsLocations.url)
+      .catch((err) => {
+        log.info(`Unable to do HTTP GET for apps locations: ${err.message}`);
+        return null;
+      });
+
+    const parsed = FdmDataFetcher.#parseAxiosResponse(response);
+
+    return parsed;
+  }
+
   async doPermMessagesHttpGet() {
     // we get the compressed output. 56Mb vs 11Mb
     // this is still ridiculous though - we don't need to fetch the entire

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -708,7 +708,7 @@ class FdmDataFetcher extends EventEmitter {
     appsLocations.etag = etag;
     appsLocations.maxAgeMs = maxAgeMs;
 
-    const fetchTime = FdmDataFetcher.now;
+    // const fetchTime = FdmDataFetcher.now;
 
     // we could get the response as text and hash that, but it changes
     // the logic quite a bit. So a better compromise is to stringify again
@@ -722,10 +722,12 @@ class FdmDataFetcher extends EventEmitter {
       await this.processAppsLocations(payload);
     }
 
-    const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
+    // const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
     // add a one second overlay here. This stops retries when the max-age is
     // at 0.
-    const sleepTimeMs = Math.max(1_000, maxAgeMs - elapsedMs + 1_000);
+    // const sleepTimeMs = Math.max(1_000, maxAgeMs - elapsedMs + 1_000);
+    // test hardsetting this to 10 seconds (we try a different node on each call)
+    const sleepTimeMs = 10_000;
 
     const logger = {
       name: 'appsLocations',

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -640,7 +640,7 @@ class FdmDataFetcher extends EventEmitter {
       verb: 'get',
       backend,
       etag,
-      specSize: payload ? payload.length : 0,
+      payloadSize: payload ? payload.length : 0,
       sleepTimeMs,
       timestamp: FdmDataFetcher.timestamp(),
     };
@@ -686,7 +686,7 @@ class FdmDataFetcher extends EventEmitter {
       verb: 'get',
       backend,
       etag,
-      specSize: payload ? payload.length : 0,
+      payloadSize: payload ? payload.length : 0,
       sleepTimeMs,
       timestamp: FdmDataFetcher.timestamp(),
     };
@@ -732,7 +732,7 @@ class FdmDataFetcher extends EventEmitter {
       verb: 'get',
       backend,
       etag,
-      specSize: payload ? payload.length : 0,
+      payloadSize: payload ? payload.length : 0,
       sleepTimeMs,
       timestamp: FdmDataFetcher.timestamp(),
     };

--- a/src/services/flux/dataFetcher.js
+++ b/src/services/flux/dataFetcher.js
@@ -713,15 +713,16 @@ class FdmDataFetcher extends EventEmitter {
     // we could get the response as text and hash that, but it changes
     // the logic quite a bit. So a better compromise is to stringify again
     // until the load balancers are fixed (return same api endpoint, i.e. same etag)
-    const hasher = crypto.createHash('sha1');
-    const locationsSha = hasher.update(JSON.stringify(payload)).digest('hex');
+    // const hasher = crypto.createHash('sha1');
+    // const locationsSha = hasher.update(JSON.stringify(payload)).digest('hex');
 
-    if (locationsSha !== appsLocations.sha) {
-      console.log('appsLocations have a different SHA... processing');
-      appsLocations.sha = locationsSha;
-      await this.processAppsLocations(payload);
-    }
+    // if (locationsSha !== appsLocations.sha) {
+    //   console.log('appsLocations have a different SHA... processing');
+    //   appsLocations.sha = locationsSha;
+    //   await this.processAppsLocations(payload);
+    // }
 
+    await this.processAppsLocations(payload);
     // const elapsedMs = Number(FdmDataFetcher.now - fetchTime) / 1_000_000;
     // add a one second overlay here. This stops retries when the max-age is
     // at 0.
@@ -872,16 +873,19 @@ class FdmDataFetcher extends EventEmitter {
    * @returns {Promise<number>} Ms until next loop time
    */
   async appsLocationsRunner() {
-    const { appsLocations } = this.endpoints;
+    // don't do the head request here anymore, as the endpoint is always different.
+    // this is now hardcoded to run every 10 seconds
 
-    if (appsLocations.etag) {
-      const store = appsLocations;
-      const fetcher = this.doAppsLocationsHttpHead.bind(this);
+    // const { appsLocations } = this.endpoints;
 
-      const cacheMaxAgeMs = await FdmDataFetcher.getHttpCacheValues(store, fetcher);
+    // if (appsLocations.etag) {
+    //   const store = appsLocations;
+    //   const fetcher = this.doAppsLocationsHttpHead.bind(this);
 
-      if (cacheMaxAgeMs) return cacheMaxAgeMs;
-    }
+    //   const cacheMaxAgeMs = await FdmDataFetcher.getHttpCacheValues(store, fetcher);
+
+    //   if (cacheMaxAgeMs) return cacheMaxAgeMs;
+    // }
 
     const getMaxAgeMs = await this.getAndProcessAppsLocations();
 

--- a/src/services/flux/index.js
+++ b/src/services/flux/index.js
@@ -93,7 +93,7 @@ async function getApplicationLocation(appName) {
   try {
     const fluxnodeList = await axios.get(
       `https://api.runonflux.io/apps/location/${appName}`,
-      axiosConfig,
+      { timeout: 3_000 },
     );
     if (fluxnodeList.data.status === 'success') {
       return fluxnodeList.data.data || [];

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -400,7 +400,7 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary) {
   acl is_roundrobin_endpoint path_beg /apps/appregister
   acl is_roundrobin_endpoint path_beg /apps/appupdate
   acl is_roundrobin_endpoint path_beg /apps/temporarymessages
-  acl is_roundrobin_endpoint path_beg /apps/location
+  acl is_roundrobin_endpoint path_beg /apps/location/
   acl is_roundrobin_endpoint path_beg /apps/testappinstall\n`;
 
   const webSocketAcl = `  acl is_websocket hdr(connection) -i upgrade

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -400,7 +400,7 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary) {
   acl is_roundrobin_endpoint path_beg /apps/appregister
   acl is_roundrobin_endpoint path_beg /apps/appupdate
   acl is_roundrobin_endpoint path_beg /apps/temporarymessages
-  acl is_roundrobin_endpoint path_beg /apps/location/
+  acl is_roundrobin_endpoint path_beg /apps/location
   acl is_roundrobin_endpoint path_beg /apps/testappinstall\n`;
 
   const webSocketAcl = `  acl is_websocket hdr(connection) -i upgrade


### PR DESCRIPTION
Now uses `/apps/locations` to get all the app locations in one go (instead of calling /apps/location/<name> for each app). It runs every 10 seconds on a different node (round robin). The compressed size of this calls is 0.37Mb... so not bad.

We now also sort the ips for all the apps that have checks as these were being randomly generated depending on how long the network calls took. We only do this for specific apps that have checks - like the explorer etc.

If an app is missing locations, it will try 5 other nodes from the balancer pool to get locations.

Here is a screenshot of it running on `fdm-eu-2-1`:

<img width="1250" height="842" alt="Screenshot 2025-07-31 at 1 09 44 PM" src="https://github.com/user-attachments/assets/46008a1d-36ef-47d7-bece-9e341280f428" />

Due to what I think are issues with the explorer checks (and a couple of other checks) the ip's for a couple of apps always change, which means the config is reloaded a lot more than it should be. We should move these checks to haproxy, where they belong.

Over the next few days, I will do up a design / architecture document for how I want FDM to work in the future. This will include using haproxy dataplane and runtime api's, and streaming application state events from multiple nodes to build application backends. This has many advantages over the way we are doing it now - including realtime backend updates without having to reload.

Once I have approval - I can then implement it