### PR TITLE
fix: route kaspa testnet apps through tcp mode in haproxy

### DIFF
--- a/src/services/application/custom.js
+++ b/src/services/application/custom.js
@@ -29,7 +29,8 @@ function getCustomConfigs(specifications, isGsyncthingApp) {
     defaultConfig.ssl = true;
   }
 
-  if (specifications.name.toLowerCase().includes('kaspanode')) {
+  if (specifications.name.toLowerCase().startsWith('kaspanode')
+    || specifications.name.toLowerCase().startsWith('kaspatestnet')) {
     defaultConfig.mode = 'tcp';
   }
 


### PR DESCRIPTION
## Summary

- Kaspa mainnet apps (`kaspanode*`) get haproxy plaintext TCP frontends on their declared ports, but the testnet app (`kaspatestnet16gb1773890998164`) does not — `ws://…:17210` / `:18210` are refused at the LB while `wss://…:443` works.
- Root cause: the allowlist in `src/services/application/custom.js` only matches names containing `kaspanode`, so testnet apps stay at `mode='http'` and `haproxyTemplate.js` never emits the per-port `frontend tcp_app_<port>` / `bind 0.0.0.0:<port>` listeners for them. 443 SNI routing is independent of `mode`, which is why TLS keeps working.
- Fix: switch to `startsWith` and also match `kaspatestnet`. Tighter than `includes` (won't match names that contain the substring mid-string) and narrower than `startsWith('kaspa')` (avoids pulling in the HTTP `kaspa-test-explorer` app).

Affected app counts across current global specs (688 total):
- `kaspanode*`: 20 apps (unchanged behavior)
- `kaspatestnet*`: 1 app — `kaspatestnet16gb1773890998164` (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)