### PR TITLE
fix: return full ip:port socket from /appips (UPnP master flap)

### DIFF
--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -80,7 +80,12 @@ function getAppIpsAPI(req, res) {
       return res.status(404).json(errMessage);
     }
 
-    const uniqueIps = [...new Set(matchingApps.flatMap((app) => app.ips.map((ip) => ip.split(':')[0])))];
+    // Return the full ip:port socket address. FluxOS' masterSlaveApps uses this to
+    // identify the primary node, and a bare IP gets normalized to the default API port
+    // (16127), which never matches a UPnP node running on a non-default port (e.g. :16157).
+    // Preserving the port lets the consumer compare socket addresses directly. For
+    // default-port nodes the stored address is already bare, so it passes through unchanged.
+    const uniqueIps = [...new Set(matchingApps.flatMap((app) => app.ips))];
 
     const resMessage = serviceHelper.createDataMessage({
       appName: matchingApps[0].name,

--- a/tests/appIpsTest.js
+++ b/tests/appIpsTest.js
@@ -1,0 +1,106 @@
+/* eslint-disable func-names */
+const chai = require('chai');
+
+const { expect } = chai;
+
+const domainService = require('../src/services/domainService');
+const apiService = require('../src/services/api');
+
+// Minimal Express res double that captures status + json payload.
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe('getAppIpsAPI - /appips port preservation', () => {
+  let originalGetConfiguredApps;
+
+  beforeEach(() => {
+    originalGetConfiguredApps = domainService.getConfiguredApps;
+  });
+
+  afterEach(() => {
+    domainService.getConfiguredApps = originalGetConfiguredApps;
+  });
+
+  function stubConfiguredApps(apps) {
+    domainService.getConfiguredApps = () => ({
+      nonGApps: apps,
+      gApps: [],
+      nonGAppsInitialized: true,
+      gAppsInitialized: true,
+    });
+  }
+
+  it('returns the full ip:port socket for a UPnP (non-default-port) master', () => {
+    stubConfiguredApps([
+      { name: 'valheim1777035136949', ips: ['90.228.196.203:16157'] },
+    ]);
+    const res = makeRes();
+
+    apiService.getAppIpsAPI({ params: { appname: 'valheim1777035136949' } }, res);
+
+    expect(res.statusCode).to.equal(200);
+    expect(res.body.status).to.equal('success');
+    // The port must survive - this is what lets FluxOS match a UPnP master.
+    expect(res.body.data.ips).to.deep.equal(['90.228.196.203:16157']);
+    expect(res.body.data.count).to.equal(1);
+  });
+
+  it('passes a bare default-port IP through unchanged', () => {
+    stubConfiguredApps([
+      { name: 'someapp', ips: ['10.0.0.5'] },
+    ]);
+    const res = makeRes();
+
+    apiService.getAppIpsAPI({ params: { appname: 'someapp' } }, res);
+
+    expect(res.body.data.ips).to.deep.equal(['10.0.0.5']);
+  });
+
+  it('dedupes identical socket addresses across components', () => {
+    stubConfiguredApps([
+      { name: 'multi', ips: ['1.2.3.4:16157', '5.6.7.8:16137'] },
+      { name: 'multi', ips: ['1.2.3.4:16157'] },
+    ]);
+    const res = makeRes();
+
+    apiService.getAppIpsAPI({ params: { appname: 'multi' } }, res);
+
+    expect(res.body.data.ips).to.deep.equal(['1.2.3.4:16157', '5.6.7.8:16137']);
+    expect(res.body.data.count).to.equal(2);
+  });
+
+  it('preserves distinct ports for the same IP (does not collapse by IP)', () => {
+    // Two different sockets that share an IP must both survive - the pre-fix
+    // .split(':')[0] collapsed these into a single bare IP.
+    stubConfiguredApps([
+      { name: 'app', ips: ['1.2.3.4:16157', '1.2.3.4:16137'] },
+    ]);
+    const res = makeRes();
+
+    apiService.getAppIpsAPI({ params: { appname: 'app' } }, res);
+
+    expect(res.body.data.ips).to.deep.equal(['1.2.3.4:16157', '1.2.3.4:16137']);
+    expect(res.body.data.count).to.equal(2);
+  });
+
+  it('404s when the app is not configured', () => {
+    stubConfiguredApps([]);
+    const res = makeRes();
+
+    apiService.getAppIpsAPI({ params: { appname: 'missing' } }, res);
+
+    expect(res.statusCode).to.equal(404);
+  });
+});


### PR DESCRIPTION
## Problem

A master/slave app (e.g. `valheim1777035136949`) whose primary lands on a **UPnP node** never stays up. The primary container starts, loads, then gets stopped ~30s later — endlessly. On the affected master we observed **268 starts / 268 stops in a single day**, leaving the FDM domain pointing at a server that is down most of the time, so users can't connect.

## Root cause

The master is selected by FluxOS `masterSlaveApps`, which asks FDM `GET /appips/<app>` for the current primary and compares it against the node's own socket address (`localSocketAddr`).

This endpoint stripped the port before returning:

```js
const uniqueIps = [...new Set(matchingApps.flatMap((app) => app.ips.map((ip) => ip.split(':')[0])))];
```

`app.ips` internally holds full `ip:port` sockets (HAProxy depends on it), but `/appips` returned a **bare IP**. FluxOS' `socketAddressesMatch` normalizes a bare IP to the **default API port `16127`**. For a UPnP master on a non-default port (e.g. `:16157`):

```
socketAddressesMatch("90.228.196.203:16157", "90.228.196.203")
  → normalizeSocketAddress("90.228.196.203")  →  "90.228.196.203:16127"
  → 16157 ≠ 16127  →  false
```

So the master fails to recognise **itself** as the primary and stops its own container. Next cycle there is no primary, it restarts, and the loop repeats. Default-port nodes accidentally matched (their real port *is* 16127), which is why only UPnP-hosted masters flap — and ~73% of the fleet is UPnP.

## Fix

Return the stored `ip:port` socket unchanged:

```js
const uniqueIps = [...new Set(matchingApps.flatMap((app) => app.ips))];
```

- The port is preserved for UPnP nodes, so FluxOS can match the master directly.
- Default-port nodes are already stored bare, so they pass through unchanged.
- The `{ ips, count }` **response shape is unchanged** — `ips` still holds an array; the values just retain their port now.

## Consumer audit (response contract change)

`/appips` is consumed in several places. All were checked; **none break** on `ip:port` because they already strip the port defensively:

| Consumer | Handling | Verdict |
|---|---|---|
| FluxOS `masterSlaveApps` (advancedWorkflows.js) | companion PR keeps the full socket | 🎯 beneficiary |
| `appsmonitor` `notifyNewPrimary.js` | `ips[0].split(':')[0]` | ✅ safe |
| `flux-apps-dns-manager` `fluxApi.js` | `ips[0].split(':')[0]` ("strip port if present") | ✅ safe |
| `fluxos-frontend` `[appName].vue` | `const primaryIpWithPort = ips[0]; …split(':')` | ✅ safe (written anticipating `ip:port`) |
| `RunOnFlux/flux` `appOperations.js` (older branch) | `extractIp(ips[0])` | ✅ tolerant; gets the real fix on rebase |

Caveat: this audit covers locally-available repos. A `/appips` consumer outside these repos (a cloud dashboard / server-side service) wasn't visible — but every known consumer follows the "split off the port" convention, so risk is low.

## Rollout ordering

Ship **this FDM change first**, then the FluxOS companion. No ordering regresses:

- Old FluxOS (`extractIp`) ignores the port → this change is transparent to the current fleet.
- A UPnP master is only fixed once **both** the FDM change is live **and** that node runs patched FluxOS — and FDM-first means each node self-heals the moment it updates, with no "should-be-fixed-but-isn't" window.

Companion PR: `RunOnFlux/flux` — *fix: keep FDM master socket port in masterSlaveApps*.

## Testing

`tests/appIpsTest.js` (new, 5 passing): port preserved for a UPnP socket, bare default-port passes through unchanged, dedup of identical sockets, distinct-ports-same-IP not collapsed, 404 when app absent.

*PR description written against commit `46e343d`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
