### PR TITLE
fix(haproxy): raise round-robin API backend timeout server 30s -> 120s

### DIFF
--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -384,7 +384,7 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary, cloudU
     retries 3
     # Enhanced WebSocket support
     timeout tunnel 7200s
-    timeout server 30s
+    timeout server 120s
     timeout connect 5s
     # WebSocket connection handling
     option http-keep-alive


### PR DESCRIPTION
## Issue
The round-robin API backend fronts `/apps/appregister`, `/apps/appupdate`, `/apps/testappinstall` and the `verifyapp*specifications` endpoints with a **30s server-inactivity timeout**. Registering or verifying a large multi-component app makes the receiving node verify every component's image against its registry before sending any response. On a cold node that takes ~29–33s — right at the 30s wall — so the request intermittently crosses 30s and the LB returns a **504** (appregister) or resets the **HTTP/2 stream** (testappinstall). Each attempt round-robins to a random node, so it succeeds only when that node's verification cache is warm — exactly the reported "fails most of the time, occasionally works".

## Change
Raise this one backend's `timeout server` to **120s**. It's a per-byte inactivity *ceiling*, not a fixed delay, so the fast control-plane calls sharing the backend are unaffected; it only holds a genuinely silent backend up to 120s before the LB gives up. `timeout client` (defaults, 120s) governs the client side and is unchanged. No frontend change required. `apiBackend` and `uiBackend` keep their own 30s.

## Testing (dev FDM, same round-robin backend, identical 10-component spec)
| timeout | result |
|---|---|
| **30s** | 4 of 5 cold verifications → **504** (~30.1s); the one 200 hit a cache-warm node (0.3s) |
| **120s** | **5 of 5 → 200** |

Cold end-to-end verification measured at ~29–33s, well under 120s.

## Quick hack — not the real fix
This deliberately papers over an architectural weakness in FluxOS: a synchronous, held-open HTTP request doing minutes-capable work (per-component registry verification + broadcast/propagation polling) behind a short LB inactivity timeout. The proper, scalable fix belongs in **FluxOS** and is already designed:
- move these endpoints to an **async request-reply contract** (202 Accepted + a pollable operation resource) so the kickoff returns in <1s; and
- make verification cheap: **parallelize** the per-component verify loop, **drop the per-arch 1s pacing sleep** (~20s of the ~33s), and **stop verifying each image twice**.

Once that ships, revert this timeout bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
