### PR TITLE
fix(g-apps): identify the master by its g: components, not any container name match

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/RunOnFlux/flux-domain-manager#readme",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "mocha tests --timeout 10000",
+    "test": "mocha tests --timeout 10000 --exit",
     "test:integration": "mocha tests/integration --timeout 20000",
     "test:cloudflare": "mocha tests/integration --timeout 20000 --grep 'cloudflareService'",
     "lint": "eslint ./",

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -132,7 +132,7 @@ async function isVersionOK(ip, port) {
   try {
     const url = `http://${ip}:${port}/flux/info`;
     const response = await serviceHelper.httpGetRequest(url, timeout);
-    const version = response.data.data.flux.version;
+    const { version } = response.data.data.flux;
     if (minVersionSatisfy(version, '8.2.0')) {
       if (response.data.data.flux.development === 'false' || !response.data.data.flux.development) {
         return true;
@@ -914,8 +914,55 @@ async function checkBittensor(ip, port) {
   }
 }
 
-async function checkAppRunning(url, appName) {
+/**
+ * Mirrors FluxOS dockerService.getAppDockerNameIdentifier: the docker name is the
+ * bare identifier under the flux namespace, and a name that already starts with
+ * `flux` is not prefixed again.
+ * @param {string} baseName bare identifier (`{component}_{app}`, or `{app}` for v1-3)
+ * @returns {string} docker name as reported in listrunningapps Names[0]
+ */
+function getDockerNameIdentifier(baseName) {
+  return baseName.startsWith('flux') ? `/${baseName}` : `/flux${baseName}`;
+}
+
+/**
+ * The docker names of the components that only run on a g: app's elected master.
+ * Every instance of a compose app runs the components without g: storage, so those
+ * say nothing about which node is the master.
+ * @param {Object} appSpec full application specification
+ * @returns {string[]} docker names that identify the master when running
+ */
+function getGComponentDockerNames(appSpec) {
+  if (appSpec.version <= 3) {
+    return appSpec.containerData.includes('g:')
+      ? [getDockerNameIdentifier(appSpec.name)]
+      : [];
+  }
+  return appSpec.compose
+    .filter((comp) => comp.containerData.includes('g:'))
+    .map((comp) => getDockerNameIdentifier(`${comp.name}_${appSpec.name}`));
+}
+
+/**
+ * Whether a node is the elected master of a g: application.
+ * Only the master runs g: components, so any one of them running identifies it.
+ * A master whose other components have stopped is still the master, and still
+ * serves the ports of the components it does have up, so this deliberately does
+ * not require all of them.
+ * @param {string} url node ip, optionally with api port
+ * @param {Object} appSpec full application specification
+ * @returns {Promise<boolean>} true if any g: component is running there
+ */
+async function checkAppRunning(url, appSpec) {
   try {
+    const expectedNames = getGComponentDockerNames(appSpec);
+    if (!expectedNames.length) {
+      // Only reachable if a non-g: app got routed down the g: path. Passing here
+      // would green-light every node, so refuse instead of guessing.
+      log.warn(`checkAppRunning: app ${appSpec.name} has no g: component, cannot identify a master`);
+      return false;
+    }
+
     const { CancelToken } = axios;
     const source = CancelToken.source();
     let isResolved = false;
@@ -931,10 +978,8 @@ async function checkAppRunning(url, appName) {
     const response = await axios.get(`http://${ip}:${port}/apps/listrunningapps`, { timeout: checkAppRunningTimeout, cancelToken: source.token });
     isResolved = true;
     const appsRunning = response.data.data;
-    if (appsRunning.find((app) => app.Names[0].includes(appName))) {
-      return true;
-    }
-    return false;
+    const runningNames = appsRunning.map((app) => app.Names[0]);
+    return expectedNames.some((name) => runningNames.includes(name));
   } catch (error) {
     return false;
   }
@@ -1053,6 +1098,7 @@ module.exports = {
   checkAlgorand,
   checkEthers,
   checkAppRunning,
+  getGComponentDockerNames,
   checkALPHexplorer,
   checkErgoHeight,
   isArcaneOS,

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -918,6 +918,12 @@ async function checkBittensor(ip, port) {
  * Mirrors FluxOS dockerService.getAppDockerNameIdentifier: the docker name is the
  * bare identifier under the flux namespace, and a name that already starts with
  * `flux` is not prefixed again.
+ * FluxOS's underlying getAppIdentifier has two more branches that are deliberately
+ * not mirrored here: names already starting with `zel` stay unprefixed, and the
+ * hardcoded legacy apps KadenaChainWebNode / FoldingAtHomeB get a `zel` prefix.
+ * Neither branch applies to any g: app, and if one ever did, the name produced
+ * here would simply never match a running container: the app would fail closed
+ * (no master found, dropped from haproxy) rather than route to a standby.
  * @param {string} baseName bare identifier (`{component}_{app}`, or `{app}` for v1-3)
  * @returns {string} docker name as reported in listrunningapps Names[0]
  */

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -250,15 +250,15 @@ function selectLowestDigitSumIp(ips) {
   return chosenIp;
 }
 
-async function checkAppRunningWithRetries(ip, appName, retries = G_APP_HEALTH_RETRY_COUNT) {
+async function checkAppRunningWithRetries(ip, app, retries = G_APP_HEALTH_RETRY_COUNT) {
   for (let attempt = 1; attempt <= retries; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop
-    const isOk = await applicationChecks.checkAppRunning(ip, appName);
+    const isOk = await applicationChecks.checkAppRunning(ip, app);
     if (isOk) {
       return true;
     }
     if (attempt < retries) {
-      log.info(`G App ${appName} health check attempt ${attempt}/${retries} failed for ${ip}, retrying...`);
+      log.info(`G App ${app.name} health check attempt ${attempt}/${retries} failed for ${ip}, retrying...`);
       // eslint-disable-next-line no-await-in-loop
       await serviceHelper.timeout(G_APP_HEALTH_RETRY_DELAY_MS);
     }
@@ -275,7 +275,7 @@ async function selectIPforG(ips, app) {
     const stickyIp = mapOfNamesIps[app.name];
     if (stickyIp && ips.includes(stickyIp)) {
       // Sticky IP still exists in locations - health check it with retries
-      const isOk = await checkAppRunningWithRetries(stickyIp, app.name);
+      const isOk = await checkAppRunningWithRetries(stickyIp, app);
       if (isOk) {
         mapOfNamesIpsLastHealthy[app.name] = Date.now();
         return stickyIp;
@@ -309,7 +309,7 @@ async function selectIPforG(ips, app) {
 
     for (const candidate of candidates) {
       // eslint-disable-next-line no-await-in-loop
-      const isOk = await checkAppRunningWithRetries(candidate, app.name);
+      const isOk = await checkAppRunningWithRetries(candidate, app);
       if (isOk) {
         mapOfNamesIps[app.name] = candidate;
         mapOfNamesIpsLastHealthy[app.name] = Date.now();

--- a/tests/gAppMasterCheckTest.js
+++ b/tests/gAppMasterCheckTest.js
@@ -1,0 +1,138 @@
+/* eslint-disable func-names */
+const chai = require('chai');
+const http = require('http');
+
+const { expect } = chai;
+const checks = require('../src/services/application/checks');
+
+const { getGComponentDockerNames, checkAppRunning } = checks;
+
+// zizy: the app component holds the g: volume, mysql has its own local storage.
+// Only the elected master runs fluxapp_zizy; every instance runs fluxmysql_zizy.
+const zizySpec = {
+  version: 8,
+  name: 'zizy',
+  compose: [
+    { name: 'app', containerData: 'g:/appdata' },
+    { name: 'mysql', containerData: '/var/lib/mysql' },
+  ],
+};
+
+const masterContainers = [
+  { Names: ['/fluxmysql_zizy'] },
+  { Names: ['/fluxapp_zizy'] },
+];
+const standbyContainers = [{ Names: ['/fluxmysql_zizy'] }];
+
+function serveRunningApps(containers) {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'success', data: containers }));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+describe('g: app master health check', () => {
+  describe('getGComponentDockerNames', () => {
+    it('returns only the g: component, not every component of the app', () => {
+      expect(getGComponentDockerNames(zizySpec)).to.deep.equal(['/fluxapp_zizy']);
+    });
+
+    it('returns the bare app container for a v1-3 g: app', () => {
+      const spec = { version: 3, name: 'legacyapp', containerData: 'g:/data' };
+      expect(getGComponentDockerNames(spec)).to.deep.equal(['/fluxlegacyapp']);
+    });
+
+    it('returns nothing for a v1-3 app without g: storage', () => {
+      const spec = { version: 3, name: 'legacyapp', containerData: '/data' };
+      expect(getGComponentDockerNames(spec)).to.deep.equal([]);
+    });
+
+    it('does not prefix a component that is already flux-namespaced', () => {
+      const spec = {
+        version: 8,
+        name: 'bar',
+        compose: [{ name: 'fluxy', containerData: 'g:/data' }],
+      };
+      expect(getGComponentDockerNames(spec)).to.deep.equal(['/fluxy_bar']);
+    });
+
+    it('returns every g: component when an app has more than one', () => {
+      const spec = {
+        version: 8,
+        name: 'multi',
+        compose: [
+          { name: 'one', containerData: 'g:/a' },
+          { name: 'two', containerData: 'g:/b' },
+          { name: 'three', containerData: '/local' },
+        ],
+      };
+      expect(getGComponentDockerNames(spec)).to.deep.equal(['/fluxone_multi', '/fluxtwo_multi']);
+    });
+  });
+
+  describe('checkAppRunning', () => {
+    let server;
+
+    afterEach(() => {
+      if (server) server.close();
+      server = null;
+    });
+
+    it('reports the master running the g: component as healthy', async () => {
+      server = await serveRunningApps(masterContainers);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, zizySpec);
+      expect(result).to.equal(true);
+    });
+
+    // Regression: the previous substring match on container names saw fluxmysql_zizy,
+    // reported the standby as healthy, and pinned traffic to a node serving nothing.
+    it('reports a standby running only the non-g: component as unhealthy', async () => {
+      server = await serveRunningApps(standbyContainers);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, zizySpec);
+      expect(result).to.equal(false);
+    });
+
+    // pokerflux/sftpnginx shape: the master runs one g: component and not another.
+    // It still owns the g: data and still serves that component's ports, so
+    // withdrawing it from routing would take working ports offline.
+    it('still recognises a master whose other g: component has stopped', async () => {
+      const spec = {
+        version: 7,
+        name: 'pokerflux',
+        compose: [
+          { name: 'pokerth', containerData: 'g:/pokerth' },
+          { name: 'nginx', containerData: 'g:/etc/letsencrypt' },
+          { name: 'ddns', containerData: 'g:/tmp' },
+        ],
+      };
+      server = await serveRunningApps([{ Names: ['/fluxpokerth_pokerflux'] }]);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, spec);
+      expect(result).to.equal(true);
+    });
+
+    it('does not match a different app that shares a name prefix', async () => {
+      server = await serveRunningApps([{ Names: ['/fluxapp_zizy2'] }]);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, zizySpec);
+      expect(result).to.equal(false);
+    });
+
+    it('refuses an app with no g: component rather than passing every node', async () => {
+      server = await serveRunningApps(masterContainers);
+      const spec = {
+        version: 8,
+        name: 'zizy',
+        compose: [{ name: 'app', containerData: '/appdata' }],
+      };
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, spec);
+      expect(result).to.equal(false);
+    });
+
+    it('reports unhealthy when the node cannot be reached', async () => {
+      const result = await checkAppRunning('127.0.0.1:1', zizySpec);
+      expect(result).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`selectIPforG` decides which node is a g: app's master by asking `checkAppRunning`, which matched **any running container whose name contains the app name**:

```js
if (appsRunning.find((app) => app.Names[0].includes(appName))) return true;
```

For a compose app the components without `g:` storage run on **every** instance, so a standby answers exactly like the master. Example: app `zizy` has components `app` (g:, the only one that runs on the master) and `mysql` (local storage, runs everywhere). On the standby only `/fluxmysql_zizy` runs — and `'/fluxmysql_zizy'.includes('zizy')` is `true`, so the standby reported healthy.

### Consequences observed in production

Each FDM region elects the master independently with in-memory sticky state, and the candidate order tries the lowest octet-sum IP first. With the health check unable to tell master from standby, two regions pinned `zizy` to a standby whose app container is deliberately not started:

| FDM region | routed zizy to | reality |
|---|---|---|
| EU | `167.235.183.159` | master (serving) |
| US | `176.9.25.176` | standby — port closed, **503 for every request** |
| SG | `176.9.25.176` | standby — **503** |

The wrong pick could never rotate away: the 90s unhealthy threshold in `selectIPforG` never trips because the standby always passes the check, and haproxy cannot compensate because g: app backends are generated with `check` disabled and a single server. Every FDM restart re-elects the same standby (lowest octet sum first + broken check), so the state survives restarts indefinitely.

The unanchored substring is also a latent cross-app false positive: checking app `zizy` would match a container of a different app named `zizy2`.

## Fix

Identify the master by the containers that only a master runs — the `g:` components — matched **exactly** by their docker names:

- component docker names follow FluxOS `dockerService.getAppDockerNameIdentifier`: `/flux{component}_{app}` for compose, `/flux{app}` for v1–3, with a name already starting with `flux` not prefixed again
- a node is the master if **any** of the app's g: components is running there. Requiring *all* would be wrong: a master whose secondary g: component has stopped still owns the synced data and still serves the ports of the components it does have up (live examples: `pokerflux`, `sftpnginx`)
- an app with no g: component reaching this path fails closed with a warning instead of green-lighting every node

`checkAppRunning` now receives the app specification instead of just the name; its only caller is `checkAppRunningWithRetries` inside the g: path.

## Behaviour change: stricter failure than before

If **every** g: component of an app is down on the elected master for longer than the 90 s unhealthy threshold while a non-g: component still serves its ports, the old check kept routing to that master; the new check accepts no candidate and the app drops out of haproxy until a g: component runs again. This is intentional: a node running no g: component cannot be shown to hold the app's synced data, so keeping it routed serves the non-g: components while hiding that the stateful part of the app is down. A master with at least one g: component up is unaffected — the check requires *any*, not *all*.

The docker-name mapping mirrors FluxOS `getAppDockerNameIdentifier` for the compose and v1–3 shapes only; the `zel`-prefix branches of FluxOS's `getAppIdentifier` are deliberately not reproduced (no g: app can hit them), and the code now documents that the failure mode, should one ever appear, is this same fail-closed drop rather than misrouting.

## Verification

- 11 new unit tests (`tests/gAppMasterCheckTest.js`) covering master/standby/degraded-master/prefix-collision/fail-closed/unreachable, plus the old code reproduced returning `true` for a standby serving nothing. The test script now passes `--exit`: module-level `setInterval` timers in `checks.js`/`ipService.js` keep the event loop alive once a test pulls them in, and without the flag the suite never terminates
- A/B against live production data across **143 multi-instance g: apps**: the fix changes the selection for exactly one app (`zizy`, repaired) and demotes two standby false-positives for another app without changing its selection; every other app's selection is byte-identical
- Deployed to the dev FDM: 10h soak, zero crashes, zero selection flapping (every g: app kept exactly one selected IP), fail-closed branch never fired
- Deployed to `fdm-usa-1-4` and `fdm-sg-1-4`: both re-elected the true master on the first cycle (standby rejected by retries, then failover), haproxy config delta was exactly the zizy server lines (16 lines, nothing else), public URL went 503 → 200, and all three regions now agree on the same master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

