### PR TITLE
feat(haproxy): keep origin connections alive and pool them for app traffic

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/RunOnFlux/flux-domain-manager#readme",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "mocha tests --timeout 10000",
+    "test": "mocha tests --timeout 10000 --exit",
     "test:integration": "mocha tests/integration --timeout 20000",
     "test:cloudflare": "mocha tests/integration --timeout 20000 --grep 'cloudflareService'",
     "lint": "eslint ./",

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -132,7 +132,7 @@ async function isVersionOK(ip, port) {
   try {
     const url = `http://${ip}:${port}/flux/info`;
     const response = await serviceHelper.httpGetRequest(url, timeout);
-    const version = response.data.data.flux.version;
+    const { version } = response.data.data.flux;
     if (minVersionSatisfy(version, '8.2.0')) {
       if (response.data.data.flux.development === 'false' || !response.data.data.flux.development) {
         return true;
@@ -914,8 +914,55 @@ async function checkBittensor(ip, port) {
   }
 }
 
-async function checkAppRunning(url, appName) {
+/**
+ * Mirrors FluxOS dockerService.getAppDockerNameIdentifier: the docker name is the
+ * bare identifier under the flux namespace, and a name that already starts with
+ * `flux` is not prefixed again.
+ * @param {string} baseName bare identifier (`{component}_{app}`, or `{app}` for v1-3)
+ * @returns {string} docker name as reported in listrunningapps Names[0]
+ */
+function getDockerNameIdentifier(baseName) {
+  return baseName.startsWith('flux') ? `/${baseName}` : `/flux${baseName}`;
+}
+
+/**
+ * The docker names of the components that only run on a g: app's elected master.
+ * Every instance of a compose app runs the components without g: storage, so those
+ * say nothing about which node is the master.
+ * @param {Object} appSpec full application specification
+ * @returns {string[]} docker names that identify the master when running
+ */
+function getGComponentDockerNames(appSpec) {
+  if (appSpec.version <= 3) {
+    return appSpec.containerData.includes('g:')
+      ? [getDockerNameIdentifier(appSpec.name)]
+      : [];
+  }
+  return appSpec.compose
+    .filter((comp) => comp.containerData.includes('g:'))
+    .map((comp) => getDockerNameIdentifier(`${comp.name}_${appSpec.name}`));
+}
+
+/**
+ * Whether a node is the elected master of a g: application.
+ * Only the master runs g: components, so any one of them running identifies it.
+ * A master whose other components have stopped is still the master, and still
+ * serves the ports of the components it does have up, so this deliberately does
+ * not require all of them.
+ * @param {string} url node ip, optionally with api port
+ * @param {Object} appSpec full application specification
+ * @returns {Promise<boolean>} true if any g: component is running there
+ */
+async function checkAppRunning(url, appSpec) {
   try {
+    const expectedNames = getGComponentDockerNames(appSpec);
+    if (!expectedNames.length) {
+      // Only reachable if a non-g: app got routed down the g: path. Passing here
+      // would green-light every node, so refuse instead of guessing.
+      log.warn(`checkAppRunning: app ${appSpec.name} has no g: component, cannot identify a master`);
+      return false;
+    }
+
     const { CancelToken } = axios;
     const source = CancelToken.source();
     let isResolved = false;
@@ -931,10 +978,8 @@ async function checkAppRunning(url, appName) {
     const response = await axios.get(`http://${ip}:${port}/apps/listrunningapps`, { timeout: checkAppRunningTimeout, cancelToken: source.token });
     isResolved = true;
     const appsRunning = response.data.data;
-    if (appsRunning.find((app) => app.Names[0].includes(appName))) {
-      return true;
-    }
-    return false;
+    const runningNames = appsRunning.map((app) => app.Names[0]);
+    return expectedNames.some((name) => runningNames.includes(name));
   } catch (error) {
     return false;
   }
@@ -1053,6 +1098,7 @@ module.exports = {
   checkAlgorand,
   checkEthers,
   checkAppRunning,
+  getGComponentDockerNames,
   checkALPHexplorer,
   checkErgoHeight,
   isArcaneOS,

--- a/src/services/application/checks.js
+++ b/src/services/application/checks.js
@@ -918,6 +918,12 @@ async function checkBittensor(ip, port) {
  * Mirrors FluxOS dockerService.getAppDockerNameIdentifier: the docker name is the
  * bare identifier under the flux namespace, and a name that already starts with
  * `flux` is not prefixed again.
+ * FluxOS's underlying getAppIdentifier has two more branches that are deliberately
+ * not mirrored here: names already starting with `zel` stay unprefixed, and the
+ * hardcoded legacy apps KadenaChainWebNode / FoldingAtHomeB get a `zel` prefix.
+ * Neither branch applies to any g: app, and if one ever did, the name produced
+ * here would simply never match a running container: the app would fail closed
+ * (no master found, dropped from haproxy) rather than route to a standby.
  * @param {string} baseName bare identifier (`{component}_{app}`, or `{app}` for v1-3)
  * @returns {string} docker name as reported in listrunningapps Names[0]
  */

--- a/src/services/domainService.js
+++ b/src/services/domainService.js
@@ -250,15 +250,15 @@ function selectLowestDigitSumIp(ips) {
   return chosenIp;
 }
 
-async function checkAppRunningWithRetries(ip, appName, retries = G_APP_HEALTH_RETRY_COUNT) {
+async function checkAppRunningWithRetries(ip, app, retries = G_APP_HEALTH_RETRY_COUNT) {
   for (let attempt = 1; attempt <= retries; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop
-    const isOk = await applicationChecks.checkAppRunning(ip, appName);
+    const isOk = await applicationChecks.checkAppRunning(ip, app);
     if (isOk) {
       return true;
     }
     if (attempt < retries) {
-      log.info(`G App ${appName} health check attempt ${attempt}/${retries} failed for ${ip}, retrying...`);
+      log.info(`G App ${app.name} health check attempt ${attempt}/${retries} failed for ${ip}, retrying...`);
       // eslint-disable-next-line no-await-in-loop
       await serviceHelper.timeout(G_APP_HEALTH_RETRY_DELAY_MS);
     }
@@ -275,7 +275,7 @@ async function selectIPforG(ips, app) {
     const stickyIp = mapOfNamesIps[app.name];
     if (stickyIp && ips.includes(stickyIp)) {
       // Sticky IP still exists in locations - health check it with retries
-      const isOk = await checkAppRunningWithRetries(stickyIp, app.name);
+      const isOk = await checkAppRunningWithRetries(stickyIp, app);
       if (isOk) {
         mapOfNamesIpsLastHealthy[app.name] = Date.now();
         return stickyIp;
@@ -309,7 +309,7 @@ async function selectIPforG(ips, app) {
 
     for (const candidate of candidates) {
       // eslint-disable-next-line no-await-in-loop
-      const isOk = await checkAppRunningWithRetries(candidate, app.name);
+      const isOk = await checkAppRunningWithRetries(candidate, app);
       if (isOk) {
         mapOfNamesIps[app.name] = candidate;
         mapOfNamesIpsLastHealthy[app.name] = Date.now();

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -366,6 +366,13 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary, cloudU
     option redispatch
     # RETRY: Retry failed requests automatically
     retries 3
+    # L7 retry when a pooled origin connection dies before any response byte
+    # arrives (the keep-alive close race). POSTs are excluded: the origin may
+    # have executed one before dying and haproxy must never replay it. Slow
+    # responses (response-timeout) are deliberately not retried: replaying an
+    # expensive request multiplies its cost.
+    retry-on conn-failure empty-response
+    http-request disable-l7-retry if METH_POST
     # Enhanced WebSocket support
     timeout tunnel 7200s
     timeout server 30s
@@ -386,6 +393,10 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary, cloudU
     option redispatch
     # RETRY: Retry failed requests automatically
     retries 3
+    # L7 retry on the keep-alive close race, never replaying POSTs; see the
+    # api backend above for the rationale
+    retry-on conn-failure empty-response
+    http-request disable-l7-retry if METH_POST
     # Enhanced WebSocket support
     timeout tunnel 7200s
     timeout server 120s
@@ -405,6 +416,10 @@ function createMainHaproxyConfig(ui, api, fluxIPs, uiPrimary, apiPrimary, cloudU
     option redispatch
     # RETRY: Retry failed requests
     retries 3
+    # L7 retry on the keep-alive close race, never replaying POSTs; see the
+    # api backend above for the rationale
+    retry-on conn-failure empty-response
+    http-request disable-l7-retry if METH_POST
     # Standard HTTP timeouts
     timeout server 30s
     timeout connect 5s

--- a/src/services/haproxyTemplate.js
+++ b/src/services/haproxyTemplate.js
@@ -45,6 +45,11 @@ defaults
   load-server-state-from-file global
   log     global
   mode    http
+  # Keep server-side connections alive and pool them between requests; a request
+  # after the first in a session may ride an idle pooled connection instead of
+  # paying a fresh TCP handshake to the origin. Explicit rather than relying on
+  # the haproxy-version default (never before 2.5, safe from 2.5 on).
+  http-reuse safe
 #  option  httplog
   option  dontlognull
   timeout connect 10000
@@ -76,7 +81,6 @@ frontend wwwhttp
 const httpsPrefix = `
 frontend wwwhttps
 #  option httplog
-  option http-server-close
   option forwardfor except 127.0.0.0/8
   http-response add-header Access-Control-Expose-Headers '*' unless { res.hdr(Access-Control-Expose-Headers) -m found }
   http-after-response add-header Access-Control-Allow-Origin "*" unless { res.hdr(Access-Control-Allow-Origin) -m found }

--- a/tests/gAppMasterCheckTest.js
+++ b/tests/gAppMasterCheckTest.js
@@ -1,0 +1,138 @@
+/* eslint-disable func-names */
+const chai = require('chai');
+const http = require('http');
+
+const { expect } = chai;
+const checks = require('../src/services/application/checks');
+
+const { getGComponentDockerNames, checkAppRunning } = checks;
+
+// zizy: the app component holds the g: volume, mysql has its own local storage.
+// Only the elected master runs fluxapp_zizy; every instance runs fluxmysql_zizy.
+const zizySpec = {
+  version: 8,
+  name: 'zizy',
+  compose: [
+    { name: 'app', containerData: 'g:/appdata' },
+    { name: 'mysql', containerData: '/var/lib/mysql' },
+  ],
+};
+
+const masterContainers = [
+  { Names: ['/fluxmysql_zizy'] },
+  { Names: ['/fluxapp_zizy'] },
+];
+const standbyContainers = [{ Names: ['/fluxmysql_zizy'] }];
+
+function serveRunningApps(containers) {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'success', data: containers }));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+describe('g: app master health check', () => {
+  describe('getGComponentDockerNames', () => {
+    it('returns only the g: component, not every component of the app', () => {
+      expect(getGComponentDockerNames(zizySpec)).to.deep.equal(['/fluxapp_zizy']);
+    });
+
+    it('returns the bare app container for a v1-3 g: app', () => {
+      const spec = { version: 3, name: 'legacyapp', containerData: 'g:/data' };
+      expect(getGComponentDockerNames(spec)).to.deep.equal(['/fluxlegacyapp']);
+    });
+
+    it('returns nothing for a v1-3 app without g: storage', () => {
+      const spec = { version: 3, name: 'legacyapp', containerData: '/data' };
+      expect(getGComponentDockerNames(spec)).to.deep.equal([]);
+    });
+
+    it('does not prefix a component that is already flux-namespaced', () => {
+      const spec = {
+        version: 8,
+        name: 'bar',
+        compose: [{ name: 'fluxy', containerData: 'g:/data' }],
+      };
+      expect(getGComponentDockerNames(spec)).to.deep.equal(['/fluxy_bar']);
+    });
+
+    it('returns every g: component when an app has more than one', () => {
+      const spec = {
+        version: 8,
+        name: 'multi',
+        compose: [
+          { name: 'one', containerData: 'g:/a' },
+          { name: 'two', containerData: 'g:/b' },
+          { name: 'three', containerData: '/local' },
+        ],
+      };
+      expect(getGComponentDockerNames(spec)).to.deep.equal(['/fluxone_multi', '/fluxtwo_multi']);
+    });
+  });
+
+  describe('checkAppRunning', () => {
+    let server;
+
+    afterEach(() => {
+      if (server) server.close();
+      server = null;
+    });
+
+    it('reports the master running the g: component as healthy', async () => {
+      server = await serveRunningApps(masterContainers);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, zizySpec);
+      expect(result).to.equal(true);
+    });
+
+    // Regression: the previous substring match on container names saw fluxmysql_zizy,
+    // reported the standby as healthy, and pinned traffic to a node serving nothing.
+    it('reports a standby running only the non-g: component as unhealthy', async () => {
+      server = await serveRunningApps(standbyContainers);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, zizySpec);
+      expect(result).to.equal(false);
+    });
+
+    // pokerflux/sftpnginx shape: the master runs one g: component and not another.
+    // It still owns the g: data and still serves that component's ports, so
+    // withdrawing it from routing would take working ports offline.
+    it('still recognises a master whose other g: component has stopped', async () => {
+      const spec = {
+        version: 7,
+        name: 'pokerflux',
+        compose: [
+          { name: 'pokerth', containerData: 'g:/pokerth' },
+          { name: 'nginx', containerData: 'g:/etc/letsencrypt' },
+          { name: 'ddns', containerData: 'g:/tmp' },
+        ],
+      };
+      server = await serveRunningApps([{ Names: ['/fluxpokerth_pokerflux'] }]);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, spec);
+      expect(result).to.equal(true);
+    });
+
+    it('does not match a different app that shares a name prefix', async () => {
+      server = await serveRunningApps([{ Names: ['/fluxapp_zizy2'] }]);
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, zizySpec);
+      expect(result).to.equal(false);
+    });
+
+    it('refuses an app with no g: component rather than passing every node', async () => {
+      server = await serveRunningApps(masterContainers);
+      const spec = {
+        version: 8,
+        name: 'zizy',
+        compose: [{ name: 'app', containerData: '/appdata' }],
+      };
+      const result = await checkAppRunning(`127.0.0.1:${server.address().port}`, spec);
+      expect(result).to.equal(false);
+    });
+
+    it('reports unhealthy when the node cannot be reached', async () => {
+      const result = await checkAppRunning('127.0.0.1:1', zizySpec);
+      expect(result).to.equal(false);
+    });
+  });
+});

--- a/tests/haproxyTemplateTest.js
+++ b/tests/haproxyTemplateTest.js
@@ -1,6 +1,7 @@
 /* eslint-disable func-names */
 const chai = require('chai');
 const config = require('config');
+const haproxyTemplate = require('../src/services/haproxyTemplate');
 
 const { expect } = chai;
 
@@ -29,5 +30,50 @@ describe('haproxyTemplate', () => {
     const primaryIP = getPrimaryIP();
     // Default rsync_config.json is fdm_fn1_app, group 1 fn host is itself: 5.39.57.42
     expect(primaryIP).to.equal('5.39.57.42');
+  });
+});
+
+describe('haproxyTemplate connection handling', () => {
+  const mainConfig = haproxyTemplate.createMainHaproxyConfig(
+    'home.runonflux.io',
+    'api.runonflux.io',
+    ['1.2.3.4:16127', '5.6.7.8:16137'],
+    'home.zel.network',
+    'api.zel.network',
+    'cloud.runonflux.io',
+    'cloud.zel.network',
+  );
+
+  const appsConfig = haproxyTemplate.createAppsHaproxyConfig([{
+    domain: 'myapp.app.runonflux.io',
+    appName: 'myapp',
+    name: 'myapp',
+    port: 36127,
+    ips: ['1.2.3.4:16127'],
+    healthcheck: [],
+    serverConfig: '',
+    mode: 'http',
+  }]);
+
+  it('origin connections are pooled, never forced closed per request', () => {
+    [mainConfig, appsConfig].forEach((cfg) => {
+      expect(cfg).to.include('http-reuse safe');
+      expect(cfg).to.not.include('http-server-close');
+    });
+  });
+
+  it('main LB backends retry the keep-alive close race but never replay POSTs', () => {
+    expect(mainConfig).to.include('backend apirunonfluxiobackend');
+    expect(mainConfig).to.include('backend apirunonfluxioroundrobinbackend');
+    expect(mainConfig).to.include('backend homerunonfluxiobackend');
+    const retryOn = mainConfig.match(/^\s*retry-on conn-failure empty-response$/gm) || [];
+    const postGuard = mainConfig.match(/^\s*http-request disable-l7-retry if METH_POST$/gm) || [];
+    expect(retryOn).to.have.lengthOf(3);
+    expect(postGuard).to.have.lengthOf(3);
+  });
+
+  it('app backends keep their full retry net', () => {
+    expect(appsConfig).to.include('retry-on conn-failure response-timeout empty-response 500');
+    expect(appsConfig).to.include('option redispatch 1');
   });
 });


### PR DESCRIPTION
> [!IMPORTANT]
> Merge #152 first. This branch is built on top of it; once #152 lands, this PR's diff reduces to the haproxy keep-alive change (737c554) and its main-LB retry hardening (a161e21).

## Problem

The apps https frontend forced `option http-server-close`: haproxy tore down its connection to the app node after **every** response, so every request paid a fresh TCP handshake to the origin — one extra edge→origin round trip per request, on top of the round trip the request itself needs. The apps answer in ~0 ms; the handshakes are most of the time-to-first-byte users see.

Cost of that extra round trip per request, measured from the edges to a Europe-hosted origin:

| edge | edge→origin RTT paid per request |
|---|---|
| EU | ~25 ms |
| USA | ~107 ms |
| SG | 170–400 ms (path also jittery) |

## Change

Remove `option http-server-close` from the shared https frontend and set `http-reuse safe` explicitly in defaults. Server-side connections now stay alive after a response and return to the server's idle pool; a request after a session's first may ride a pooled connection instead of handshaking.

This restores haproxy's own default behaviour (`http-reuse safe` is the shipped default since 2.5; writing it out makes the config independent of which haproxy a box runs). In safe mode the first request of a session always opens its own connection. A request raced by an origin closing an idle connection is retried by the `retry-on conn-failure response-timeout empty-response` already present on every app backend. Connections that must not be shared (websocket upgrades, NTLM-style auth, client-bound sources) are excluded by haproxy itself.

**The main LB config is affected too.** An earlier version of this description claimed the main LB builds its own frontend and was unchanged — that was wrong, and review caught it. The corrected analysis and the guard rails added for it are below.

Whether an app benefits depends on the app: if its server honours keep-alive, warm requests skip the origin handshake; if it sends `Connection: close`, the app hangs up itself and behaviour is identical to before. Survey of every http-mode origin in the dev config: **1,053 responding origins — 86% keep-alive (benefit), 14% close (unchanged)**.

## Main LB: what changes, and the guard rails

`generateHaproxyConfig` interpolates the same `httpsPrefix` frontend into both the apps config and the main LB (`home`/`api.runonflux.io`) config. Under haproxy's connection-mode precedence (frontend `SCL` + backend `KAL` → `SCL`), the frontend's `http-server-close` had been overriding the `option http-keep-alive` already written on the main LB backends — those lines were dead. Removing the frontend option activates them: the main LB switches to origin keep-alive as well.

That raises the keep-alive close race on a path the dev measurements did not cover: FluxOS is Express, whose default `keepAliveTimeout` is 5 s, so an origin can close an idle pooled connection at the same moment haproxy sends a request over it.

**What stock haproxy does about this race, without any retry configuration.** This is precisely the case `http-reuse safe` is designed around. The manual ([`http-reuse`](https://docs.haproxy.org/2.9/configuration.html#4.2-http-reuse)):

> "safe" : this is the default and the recommended strategy. The first request of a session is always sent over its own connection, and only subsequent requests may be dispatched over other existing connections. This ensures that in case the server closes the connection when the request is being sent, the browser can decide to silently retry it.

Because a pooled connection is only ever used for a non-first request of the client's own keep-alive session, the failure path in the source ([`http_ana.c` v2.9.15, `abort_keep_alive`, line 1665](http://git.haproxy.org/?p=haproxy-2.9.git;a=blob;f=src/http_ana.c;hb=v2.9.15#l1665), reached via the `TX_NOT_FIRST` gates at lines 1256/1352) closes the client connection with **no response at all** rather than a 502:

> /* A keep-alive request to the server failed on a network error. The client is required to retry. We need to close without returning any other information so that the client retries. */

Keep-alive clients (browsers, curl, mainstream HTTP libraries) retry that case themselves — it is indistinguishable from the ordinary HTTP/1.1 keep-alive race they already handle.

**What this PR adds on top**, on the three main LB backends (pattern from HAProxy's own guidance, [HAProxy Layer 7 Retries & Chaos Engineering](https://www.haproxy.com/blog/haproxy-layer-7-retries-and-chaos-engineering)):

```
retry-on conn-failure empty-response
http-request disable-l7-retry if METH_POST
```

GET traffic — the overwhelming bulk on these backends — now gets retried inside haproxy, invisibly to the client. POSTs are never replayed by haproxy and fall back to the built-in behaviour above.

**What this PR deliberately does NOT add there.** The app backends' full `retry-on conn-failure response-timeout empty-response 500` line was not copied, on the manual's own warnings ([`retry-on`](https://docs.haproxy.org/2.9/configuration.html#4.2-retry-on)):

- Unguarded retries can replay non-idempotent requests. `empty-response` covers not only the benign idle-close race but also "a server crash or restart **while processing** the request" — i.e. a POST whose side effects already executed. The manual: *"You have to make sure the application has a replay protection mechanism built in such as a unique transaction IDs passed in requests, or that replaying the same request has no consequence, or it is very dangerous to use any retry-on value beside 'conn-failure' and 'none'."* Hence the `METH_POST` guard.
- `response-timeout` retries amplify load: *"It generally is a bad idea to retry on such events on servers dealing with heavy database processing (full scans, etc) as it may amplify denial of service attacks."* The roundrobin API backend's `timeout server` was just raised to 120 s (#151) because slow endpoints exist; retrying them would multiply their cost.

### haproxy versions on the fleet (verified per box, 2026-07-31)

| box | haproxy |
|---|---|
| prod app edge `fdm-usa-1-4` | 2.9.15 |
| dev app edge (the soak/measurement box) | 2.9.15 |
| prod main LB EU | 2.9.15 |
| dev main LB | 3.0.11 |
| prod main LB NA / Asia | not verified in this pass |

Every directive used here exists with identical semantics since 2.0, and `http-reuse safe` is the compiled default on both branches present — declaring it pins intent rather than changing behaviour. (This also answers the review question about README's Ubuntu 20.04 distro haproxy 2.0: the boxes run PPA builds, not distro 2.0.)

## Measurements (dev FDM, live traffic — apps path)

A box is either an apps box or a main-LB box, so these measurements cover the apps path; the main LB path is guarded as above and its `eresp`/`wretr`/5xx counters should be watched after rollout.

True before/after, same protocol (8 sessions × 5 requests, warm-request median = requests 2–5):

| app | origin RTT | before | after | Δ |
|---|---|---|---|---|
| statusquipnetwork (keep-alive) | ~120 ms | 263 ms | **150 ms** | **−43%** |
| zizy (`Connection: close`) | ~14 ms | 51 ms | 52 ms | none — none possible |

Broader verification after deploy — 9 apps across different stacks and origin distances, measured warm TTFB vs the two models (client ≈22 ms + 1×RTT if the connection is reused, + 2×RTT if not):

| app | class | measured | reused model | cold model | verdict |
|---|---|---|---|---|---|
| sifchainfinance | keep-alive | 137 ms | 126–130 | 230–238 | reused ✓ |
| runonfluxos | keep-alive | 130 ms | 115–126 | 209–230 | reused ✓ |
| torn | keep-alive | 312 ms | 301 | 580 | reused ✓ |
| palworld…59110 | keep-alive | 276 ms | 262 | 502 | reused ✓ |
| statusquipnetwork | keep-alive | 150 ms | 142 | 263 | reused ✓ |
| row01 | close | 496 ms | 224–280 | 426–538 | cold, unchanged ✓ |
| na01 | close | 229 ms | 118–120 | 214–218 | cold, unchanged ✓ |
| soundstagepos | close | 221 ms | 117–123 | 212–224 | cold, unchanged ✓ |
| zizy | close | 52 ms | — | 50 | cold, unchanged ✓ |

(Two further candidates excluded for cause: one with an incompletely captured server list, one mixed-class app whose dynamic page adds real server time — mixed-class apps get reuse on their keep-alive instances only, which per-server pools handle by construction.)

Error counters after the change under live traffic, across all 3,184 backend servers on the dev box: `econ` 0, `eresp` 0, retries 0, 5xx 0.

## Regression tests

`tests/haproxyTemplateTest.js` now pins: `http-reuse safe` present and `http-server-close` absent in both generated configs; the retry pair present on exactly the three main LB backends; the app backends' existing retry net intact.

## Follow-ups (out of scope here)

- Idle-pool FD headroom: `tune.pool-low/high-fd-ratio` defaults against `global maxconn 50000` cap idle connections at ~10–12.5k FDs (~3 per server across 3,184 servers), which may cap the production reuse rate below the dev numbers; the manual suggests raising global `maxconn`. Also pre-existing: `defaults maxconn 100000` exceeds `global maxconn 50000`.
- Per-app escape hatch: an appsConfig list emitting `http-reuse never` into a specific backend, so an app that ties state to the TCP connection can be opted out without reverting the fleet.
- Root cause of the race window: Express's 5 s `keepAliveTimeout` sitting at haproxy's `pool-purge-delay` (5 s). The standard alignment fix (origin keep-alive timeout above the proxy's idle window) belongs in the FluxOS codebase, not FDM.

## Expected impact

Warm requests (everything after a page's first asset on a browser connection) stop paying the edge→origin handshake: −25 ms per request via the EU edge, −107 ms via USA, up to −400 ms via SG, for the 86% of apps whose servers keep connections alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
